### PR TITLE
Doubling up containers results in an awkward shift to the right; 

### DIFF
--- a/mps/templates/assays/assaychipreadout_list.html
+++ b/mps/templates/assays/assaychipreadout_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Readouts</h2>
 
         <table id="readouts" class="display" cellspacing="0" width="100%">

--- a/mps/templates/assays/assaychipsetup_list.html
+++ b/mps/templates/assays/assaychipsetup_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Setups</h2>
 
         <table id="setups" class="display" cellspacing="0" width="100%">

--- a/mps/templates/assays/assayrun_list.html
+++ b/mps/templates/assays/assayrun_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Studies</h2>
 
         <table id="studies" class="display" cellspacing="0" width="100%">

--- a/mps/templates/assays/assaytestresult_list.html
+++ b/mps/templates/assays/assaytestresult_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Results</h2>
 
         <table id="results" class="display" cellspacing="0" width="100%">

--- a/mps/templates/assays/index.html
+++ b/mps/templates/assays/index.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <legend><h1>{{ title }}    <a href="/assays/organchipstudy/add{{ setup }}" class="btn btn-success" role="button">Add Study</a></h1></legend>
 
         <table id="studies" class="display" cellspacing="0" width="100%">

--- a/mps/templates/assays/study_index.html
+++ b/mps/templates/assays/study_index.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <div class="well">
             <h1 align="center">Study: {{ object_list.0.assay_run_id }}</h1>
         </div>

--- a/mps/templates/bioactivities/cluster.html
+++ b/mps/templates/bioactivities/cluster.html
@@ -36,7 +36,7 @@
         </div>
     {% endblock %}
 
-    <div class="container" id="selection">
+    <div id="selection">
         <div class="row">
             <div class="col-xs-12">
                 <div class="text-center">
@@ -332,7 +332,7 @@
         }
         </style>
 
-        <div hidden id="graphic" class="container-fluid">
+        <div hidden id="graphic">
             <div class="row text-center">
                 <button id="back" class="btn btn-xlarge btn-info">
                     <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>

--- a/mps/templates/bioactivities/heatmap.html
+++ b/mps/templates/bioactivities/heatmap.html
@@ -62,7 +62,7 @@
 {% endblock %}
 
 {% block graphic %}
-    <div hidden id="graphic" class="container-fluid">
+    <div hidden id="graphic">
         <div class="row text-center">
             <button id="back" class="btn btn-xlarge btn-info">
                 <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>

--- a/mps/templates/bioactivities/table.html
+++ b/mps/templates/bioactivities/table.html
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block graphic %}
-    <div hidden id="graphic" class="container" style="padding-bottom: 50px">
+    <div hidden id="graphic" style="padding-bottom: 50px">
         <div class="row text-center">
                 <button id="back" class="btn btn-xlarge btn-info">
                     <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>

--- a/mps/templates/compounds/compounds_detail.html
+++ b/mps/templates/compounds/compounds_detail.html
@@ -74,7 +74,7 @@
         </button>
     </legend>
 
-    <div id='synonyms' class="collapse container-fluid lead">
+    <div id='synonyms' class="collapse lead">
 
         <p>{{ object.synonyms }}</p>
 

--- a/mps/templates/compounds/compounds_list.html
+++ b/mps/templates/compounds/compounds_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Compounds</h2>
 
         <table id="compounds" class="display" cellspacing="0" width="100%">

--- a/mps/templates/drugtrials/drugtrial_list.html
+++ b/mps/templates/drugtrials/drugtrial_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Drug Trials</h2>
 
         <table id="drugtrials" class="display" cellspacing="0" width="100%">

--- a/mps/templates/index.html
+++ b/mps/templates/index.html
@@ -9,7 +9,7 @@
     }
     </style>
 
-    <div class="container text-center">
+    <div class="text-center">
         <div class="row">
             <div class="col-xs-12">
                 <br/>

--- a/mps/templates/microdevices/microdevice_list.html
+++ b/mps/templates/microdevices/microdevice_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" style="padding-bottom: 50px">
+    <div style="padding-bottom: 50px">
         <h2 align="center">Microdevices</h2>
 
         <table id="microdevices" class="display" cellspacing="0" width="100%">


### PR DESCRIPTION
only have one container