### PR TITLE
Stage

### DIFF
--- a/assays/admin.py
+++ b/assays/admin.py
@@ -1181,63 +1181,63 @@ class PhysicalUnitsAdmin(LockableAdmin):
 admin.site.register(PhysicalUnits, PhysicalUnitsAdmin)
 
 
-class TimeUnitsAdmin(LockableAdmin):
-    save_on_top = True
-    list_per_page = 300
-
-    list_display = ('unit', 'unit_order',)
-    fieldsets = (
-        (
-            None, {
-                'fields': (
-                    'unit',
-                    'description',
-                    'unit_order',
-                )
-            }
-        ),
-        ('Change Tracking', {
-            'fields': (
-                'locked',
-                ('created_by', 'created_on'),
-                ('modified_by', 'modified_on'),
-                ('signed_off_by', 'signed_off_date'),
-            )
-        }
-        ),
-    )
-
-
-admin.site.register(TimeUnits, TimeUnitsAdmin)
-
-
-class ReadoutUnitAdmin(LockableAdmin):
-    save_on_top = True
-    list_per_page = 100
-
-    list_display = ('readout_unit', 'description',)
-    fieldsets = (
-        (
-            None, {
-                'fields': (
-                    'readout_unit',
-                    'description'
-                )
-            }
-        ),
-        ('Change Tracking', {
-            'fields': (
-                'locked',
-                ('created_by', 'created_on'),
-                ('modified_by', 'modified_on'),
-                ('signed_off_by', 'signed_off_date'),
-            )
-        }
-        ),
-    )
+#class TimeUnitsAdmin(LockableAdmin):
+#    save_on_top = True
+#    list_per_page = 300
+#
+#    list_display = ('unit', 'unit_order',)
+#    fieldsets = (
+#        (
+#            None, {
+#                'fields': (
+#                    'unit',
+#                    'description',
+#                    'unit_order',
+#                )
+#            }
+#        ),
+#        ('Change Tracking', {
+#            'fields': (
+#                'locked',
+#                ('created_by', 'created_on'),
+#                ('modified_by', 'modified_on'),
+#                ('signed_off_by', 'signed_off_date'),
+#            )
+#        }
+#        ),
+#    )
+#
+#
+#admin.site.register(TimeUnits, TimeUnitsAdmin)
 
 
-admin.site.register(ReadoutUnit, ReadoutUnitAdmin)
+#class ReadoutUnitAdmin(LockableAdmin):
+#    save_on_top = True
+#    list_per_page = 100
+#
+#    list_display = ('readout_unit', 'description',)
+#    fieldsets = (
+#        (
+#            None, {
+#                'fields': (
+#                    'readout_unit',
+#                    'description'
+#                )
+#            }
+#        ),
+#        ('Change Tracking', {
+#            'fields': (
+#                'locked',
+#                ('created_by', 'created_on'),
+#                ('modified_by', 'modified_on'),
+#                ('signed_off_by', 'signed_off_date'),
+#            )
+#        }
+#        ),
+#    )
+#
+#
+#admin.site.register(ReadoutUnit, ReadoutUnitAdmin)
 
 
 class AssayChipTestResultAdmin(LockableAdmin):

--- a/assays/admin.py
+++ b/assays/admin.py
@@ -942,7 +942,7 @@ class AssayChipReadoutForm(forms.ModelForm):
 class AssayChipReadoutAdmin(LockableAdmin):
     # TIMEPOINT readouts from ORGAN CHIPS
     class Media(object):
-        js = ('js/inline_fix.js','assays/customize_chip.js', 'js/d3.v3.min.js', 'js/c3.min.js',)
+        js = ('js/inline_fix.js','assays/customize_chip.js', 'js/d3.min.js', 'js/c3.min.js',)
         css = {'all': ('assays/customize_admin.css', 'css/c3.css',)}
 
     form = AssayChipReadoutForm

--- a/assays/models.py
+++ b/assays/models.py
@@ -544,7 +544,7 @@ class StudyModel(models.Model):
     """
 
     study_configuration = models.ForeignKey(StudyConfiguration)
-    label = models.CharField(max_length=1)
+    label = models.CharField(max_length=2)
     organ = models.ForeignKey(OrganModel)
     sequence_number = models.IntegerField()
     output = models.CharField(max_length=20, blank=True, null=True)

--- a/assays/models.py
+++ b/assays/models.py
@@ -27,7 +27,7 @@ class PhysicalUnits(LockableModel):
 
     unit = models.CharField(max_length=256)
     description = models.CharField(max_length=256,
-                                   default='')
+                                   blank=True, null=True)
 
     unit_type = models.CharField(default='C',
                                  max_length=2,
@@ -43,7 +43,8 @@ class PhysicalUnits(LockableModel):
                                      null=True)
 
     availability = models.CharField(max_length=256,
-                                    default='',
+                                    blank=True,
+                                    null=True,
                                     help_text=(u'Type a series of strings for indicating '
                                                u'where this unit should be listed:'
                                                u'\ntest = test results\nreadouts = readouts'))
@@ -86,7 +87,7 @@ class AssayModelType(LockableModel):
         ordering = ('assay_type_name',)
 
     assay_type_name = models.CharField(max_length=200, unique=True)
-    assay_type_description = models.TextField(default='')
+    assay_type_description = models.TextField(blank=True, null=True)
 
     def __unicode__(self):
         return self.assay_type_name
@@ -103,8 +104,9 @@ class AssayModel(LockableModel):
     assay_name = models.CharField(max_length=200, unique=True)
     assay_type = models.ForeignKey(AssayModelType)
     version_number = models.CharField(max_length=200, verbose_name='Version',
-                                      default='')
-    assay_description = models.TextField(verbose_name='Description', default='')
+                                      blank=True, null=True)
+    assay_description = models.TextField(verbose_name='Description', blank=True,
+                                         null=True)
     assay_protocol_file = models.FileField(upload_to='assays',
                                            verbose_name='Protocol File',
                                            null=True, blank=True)
@@ -114,6 +116,44 @@ class AssayModel(LockableModel):
 
     def __unicode__(self):
         return u'{0} ({1})'.format(self.assay_name, self.test_type)
+
+# To be removed
+# This model is deprecated and will be incorporated into devices
+# class AssayLayoutFormat(LockableModel):
+#     layout_format_name = models.CharField(max_length=200, unique=True)
+#     number_of_rows = models.IntegerField()
+#     number_of_columns = models.IntegerField()
+#     row_labels = models.CharField(max_length=1000,
+#                                   help_text=
+#                                   'Space separated list of unique labels, '
+#                                   'e.g. "A B C D ..."'
+#                                   ' Number of items must match'
+#                                   ' number of columns.''')
+#     column_labels = models.CharField(max_length=1000,
+#                                      help_text='Space separated list of unique '
+#                                                'labels, e.g. "1 2 3 4 ...". '
+#                                                'Number of items must match '
+#                                                'number of columns.')
+#
+#     device = models.ForeignKey(Microdevice)
+#
+#     class Meta(object):
+#         ordering = ('layout_format_name',)
+#
+#     def __unicode__(self):
+#         return self.layout_format_name
+
+# To be removed
+# This model is deprecated and will be incorporated into assay layout
+# class AssayBaseLayout(LockableModel):
+#     base_layout_name = models.CharField(max_length=200)
+#     layout_format = models.ForeignKey(AssayLayoutFormat)
+#
+#     class Meta(object):
+#         ordering = ('base_layout_name',)
+#
+#     def __unicode__(self):
+#         return self.base_layout_name
 
 
 # Assay layout is now a flaggable model
@@ -146,7 +186,7 @@ class AssayWellType(LockableModel):
         ordering = ('well_type',)
 
     well_type = models.CharField(max_length=200, unique=True)
-    well_description = models.TextField(default='')
+    well_description = models.TextField(blank=True, null=True)
     background_color = models.CharField(max_length=20,
                                         help_text='Provide color code or name. '
                                                   'You can pick one from: '
@@ -232,7 +272,7 @@ class AssayPlateCells(models.Model):
                                                         ('ML', 'cells / mL'),
                                                         ('MM', 'cells / mm^2')))
     cell_passage = models.CharField(max_length=16,verbose_name='Passage#',
-                                    default='')
+                                    blank=True, null=True)
 
 
 class AssayPlateSetup(FlaggableModel):
@@ -254,10 +294,10 @@ class AssayPlateSetup(FlaggableModel):
     # Plate identifier
     assay_plate_id = models.CharField(max_length=512, verbose_name='Plate ID/ Barcode')
 
-    scientist = models.CharField(max_length=100, default='')
-    notebook = models.CharField(max_length=256, default='')
+    scientist = models.CharField(max_length=100, blank=True, null=True)
+    notebook = models.CharField(max_length=256, blank=True, null=True)
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, default='')
+    notes = models.CharField(max_length=2048, blank=True, null=True)
 
     def __unicode__(self):
         return u'Plate-{}'.format(self.assay_plate_id)
@@ -362,10 +402,10 @@ class AssayPlateReadout(FlaggableModel):
 
     readout_start_time = models.DateField(verbose_name='Readout Date', help_text="YYYY-MM-DD")
 
-    notebook = models.CharField(max_length=256, default='')
+    notebook = models.CharField(max_length=256, blank=True, null=True)
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, default='')
-    scientist = models.CharField(max_length=100, default='')
+    notes = models.CharField(max_length=2048, blank=True, null=True)
+    scientist = models.CharField(max_length=100, blank=True, null=True)
     file = models.FileField(upload_to='csv', verbose_name='Data File',
                             blank=True, null=True)
 
@@ -396,8 +436,8 @@ class AssayResultFunction(LockableModel):
         ordering = ('function_name', )
 
     function_name = models.CharField(max_length=100, unique=True)
-    function_results = models.CharField(max_length=100, default='')
-    description = models.CharField(max_length=200, default='')
+    function_results = models.CharField(max_length=100, blank=True, null=True)
+    description = models.CharField(max_length=200, blank=True, null=True)
 
     def __unicode__(self):
         return self.function_name
@@ -413,7 +453,7 @@ class AssayResultType(LockableModel):
         ordering = ('assay_result_type', )
 
     assay_result_type = models.CharField(max_length=100, unique=True)
-    description = models.CharField(max_length=200, default='')
+    description = models.CharField(max_length=200, blank=True, null=True)
 
     def __unicode__(self):
         return self.assay_result_type
@@ -442,7 +482,9 @@ class AssayPlateResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity')
+                                verbose_name='Severity',
+                                blank=True,
+                                null=True)
 
     result_type = models.ForeignKey(AssayResultType,
                                     blank=True,
@@ -485,8 +527,8 @@ class StudyConfiguration(LockableModel):
     # Length subject to change
     name = models.CharField(max_length=50)
     study_format = models.CharField(max_length=11, choices=(('individual','Individual'),('integrated','Integrated'),))
-    media_composition = models.CharField(max_length=1000, default='')
-    hardware_description = models.CharField(max_length=1000, default='')
+    media_composition = models.CharField(max_length=1000, blank=True, null=True)
+    hardware_description = models.CharField(max_length=1000, blank=True, null=True)
     # Subject to removal
     # image = models.ImageField(upload_to="configuration",null=True, blank=True)
 
@@ -505,7 +547,7 @@ class StudyModel(models.Model):
     label = models.CharField(max_length=1)
     organ = models.ForeignKey(OrganModel)
     sequence_number = models.IntegerField()
-    output = models.CharField(max_length=20, default='')
+    output = models.CharField(max_length=20, blank=True, null=True)
     # Subject to change
     integration_mode = models.CharField(max_length=13, choices=(('0', 'Not Connected'),('1','Connected')))
 
@@ -535,7 +577,7 @@ class AssayRun(RestrictedModel):
     start_date = models.DateField(help_text='YYYY-MM-DD')
     assay_run_id = models.TextField(unique=True, verbose_name='Study ID',
                                     help_text="Standard format 'CenterID-YYYY-MM-DD-Name-###'")
-    description = models.TextField(default='')
+    description = models.TextField(blank=True, null=True)
 
     file = models.FileField(upload_to='csv', verbose_name='Batch Data File',
                             blank=True, null=True, help_text='Do not upload until you have made each Chip Readout')
@@ -591,7 +633,7 @@ class AssayChipCells(models.Model):
                                                         ('ML', 'cells / mL'),
                                                         ('MM', 'cells / mm^2')))
     cell_passage = models.CharField(max_length=16,verbose_name='Passage#',
-                                    default='')
+                                    blank=True, null=True)
 
 
 class AssayChipSetup(FlaggableModel):
@@ -606,7 +648,7 @@ class AssayChipSetup(FlaggableModel):
     setup_date = models.DateField(help_text='YYYY-MM-DD')
     device = models.ForeignKey(OrganModel, verbose_name = 'Organ Model Name')
 
-    variance = models.CharField(max_length=3000, verbose_name='Variance from Protocol', default='')
+    variance = models.CharField(max_length=3000, verbose_name='Variance from Protocol', null=True, blank=True)
 
     # the unique chip identifier
     # can be a barcode or a hand written identifier
@@ -622,10 +664,10 @@ class AssayChipSetup(FlaggableModel):
                              verbose_name='conc. Unit',
                              null=True, blank=True)
 
-    scientist = models.CharField(max_length=100, default='')
-    notebook = models.CharField(max_length=256, default='')
+    scientist = models.CharField(max_length=100, blank=True, null=True)
+    notebook = models.CharField(max_length=256, blank=True, null=True)
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, default='')
+    notes = models.CharField(max_length=2048, blank=True, null=True)
 
     def __unicode__(self):
         return u'Chip-{}:{}({}{})'.format(self.assay_chip_id,
@@ -679,10 +721,10 @@ class AssayChipReadout(FlaggableModel):
 
     readout_start_time = models.DateField(verbose_name='Readout Start Date', help_text="YYYY-MM-DD")
 
-    notebook = models.CharField(max_length=256, default='')
+    notebook = models.CharField(max_length=256, blank=True, null=True)
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, default='')
-    scientist = models.CharField(max_length=100, default='')
+    notes = models.CharField(max_length=2048, blank=True, null=True)
+    scientist = models.CharField(max_length=100, blank=True, null=True)
     file = models.FileField(upload_to='csv', verbose_name='Data File',
                             blank=True, null=True, help_text='Green = Data from database;'
                                                              ' Red = Line that will not be read'
@@ -778,7 +820,9 @@ class AssayChipResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity')
+                                verbose_name='Severity',
+                                blank=True,
+                                null=True)
 
     result_type = models.ForeignKey(AssayResultType,
                                     blank=True,

--- a/assays/models.py
+++ b/assays/models.py
@@ -27,7 +27,7 @@ class PhysicalUnits(LockableModel):
 
     unit = models.CharField(max_length=256)
     description = models.CharField(max_length=256,
-                                   blank=True, null=True)
+                                   default='')
 
     unit_type = models.CharField(default='C',
                                  max_length=2,
@@ -43,8 +43,7 @@ class PhysicalUnits(LockableModel):
                                      null=True)
 
     availability = models.CharField(max_length=256,
-                                    blank=True,
-                                    null=True,
+                                    default='',
                                     help_text=(u'Type a series of strings for indicating '
                                                u'where this unit should be listed:'
                                                u'\ntest = test results\nreadouts = readouts'))
@@ -87,7 +86,7 @@ class AssayModelType(LockableModel):
         ordering = ('assay_type_name',)
 
     assay_type_name = models.CharField(max_length=200, unique=True)
-    assay_type_description = models.TextField(blank=True, null=True)
+    assay_type_description = models.TextField(default='')
 
     def __unicode__(self):
         return self.assay_type_name
@@ -104,9 +103,8 @@ class AssayModel(LockableModel):
     assay_name = models.CharField(max_length=200, unique=True)
     assay_type = models.ForeignKey(AssayModelType)
     version_number = models.CharField(max_length=200, verbose_name='Version',
-                                      blank=True, null=True)
-    assay_description = models.TextField(verbose_name='Description', blank=True,
-                                         null=True)
+                                      default='')
+    assay_description = models.TextField(verbose_name='Description', default='')
     assay_protocol_file = models.FileField(upload_to='assays',
                                            verbose_name='Protocol File',
                                            null=True, blank=True)
@@ -116,44 +114,6 @@ class AssayModel(LockableModel):
 
     def __unicode__(self):
         return u'{0} ({1})'.format(self.assay_name, self.test_type)
-
-# To be removed
-# This model is deprecated and will be incorporated into devices
-# class AssayLayoutFormat(LockableModel):
-#     layout_format_name = models.CharField(max_length=200, unique=True)
-#     number_of_rows = models.IntegerField()
-#     number_of_columns = models.IntegerField()
-#     row_labels = models.CharField(max_length=1000,
-#                                   help_text=
-#                                   'Space separated list of unique labels, '
-#                                   'e.g. "A B C D ..."'
-#                                   ' Number of items must match'
-#                                   ' number of columns.''')
-#     column_labels = models.CharField(max_length=1000,
-#                                      help_text='Space separated list of unique '
-#                                                'labels, e.g. "1 2 3 4 ...". '
-#                                                'Number of items must match '
-#                                                'number of columns.')
-#
-#     device = models.ForeignKey(Microdevice)
-#
-#     class Meta(object):
-#         ordering = ('layout_format_name',)
-#
-#     def __unicode__(self):
-#         return self.layout_format_name
-
-# To be removed
-# This model is deprecated and will be incorporated into assay layout
-# class AssayBaseLayout(LockableModel):
-#     base_layout_name = models.CharField(max_length=200)
-#     layout_format = models.ForeignKey(AssayLayoutFormat)
-#
-#     class Meta(object):
-#         ordering = ('base_layout_name',)
-#
-#     def __unicode__(self):
-#         return self.base_layout_name
 
 
 # Assay layout is now a flaggable model
@@ -186,7 +146,7 @@ class AssayWellType(LockableModel):
         ordering = ('well_type',)
 
     well_type = models.CharField(max_length=200, unique=True)
-    well_description = models.TextField(blank=True, null=True)
+    well_description = models.TextField(default='')
     background_color = models.CharField(max_length=20,
                                         help_text='Provide color code or name. '
                                                   'You can pick one from: '
@@ -272,7 +232,7 @@ class AssayPlateCells(models.Model):
                                                         ('ML', 'cells / mL'),
                                                         ('MM', 'cells / mm^2')))
     cell_passage = models.CharField(max_length=16,verbose_name='Passage#',
-                                    blank=True, null=True)
+                                    default='')
 
 
 class AssayPlateSetup(FlaggableModel):
@@ -294,10 +254,10 @@ class AssayPlateSetup(FlaggableModel):
     # Plate identifier
     assay_plate_id = models.CharField(max_length=512, verbose_name='Plate ID/ Barcode')
 
-    scientist = models.CharField(max_length=100, blank=True, null=True)
-    notebook = models.CharField(max_length=256, blank=True, null=True)
+    scientist = models.CharField(max_length=100, default='')
+    notebook = models.CharField(max_length=256, default='')
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, blank=True, null=True)
+    notes = models.CharField(max_length=2048, default='')
 
     def __unicode__(self):
         return u'Plate-{}'.format(self.assay_plate_id)
@@ -402,10 +362,10 @@ class AssayPlateReadout(FlaggableModel):
 
     readout_start_time = models.DateField(verbose_name='Readout Date', help_text="YYYY-MM-DD")
 
-    notebook = models.CharField(max_length=256, blank=True, null=True)
+    notebook = models.CharField(max_length=256, default='')
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, blank=True, null=True)
-    scientist = models.CharField(max_length=100, blank=True, null=True)
+    notes = models.CharField(max_length=2048, default='')
+    scientist = models.CharField(max_length=100, default='')
     file = models.FileField(upload_to='csv', verbose_name='Data File',
                             blank=True, null=True)
 
@@ -436,8 +396,8 @@ class AssayResultFunction(LockableModel):
         ordering = ('function_name', )
 
     function_name = models.CharField(max_length=100, unique=True)
-    function_results = models.CharField(max_length=100, blank=True, null=True)
-    description = models.CharField(max_length=200, blank=True, null=True)
+    function_results = models.CharField(max_length=100, default='')
+    description = models.CharField(max_length=200, default='')
 
     def __unicode__(self):
         return self.function_name
@@ -453,7 +413,7 @@ class AssayResultType(LockableModel):
         ordering = ('assay_result_type', )
 
     assay_result_type = models.CharField(max_length=100, unique=True)
-    description = models.CharField(max_length=200, blank=True, null=True)
+    description = models.CharField(max_length=200, default='')
 
     def __unicode__(self):
         return self.assay_result_type
@@ -482,9 +442,7 @@ class AssayPlateResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity',
-                                blank=True,
-                                null=True)
+                                verbose_name='Severity')
 
     result_type = models.ForeignKey(AssayResultType,
                                     blank=True,
@@ -527,8 +485,8 @@ class StudyConfiguration(LockableModel):
     # Length subject to change
     name = models.CharField(max_length=50)
     study_format = models.CharField(max_length=11, choices=(('individual','Individual'),('integrated','Integrated'),))
-    media_composition = models.CharField(max_length=1000, blank=True, null=True)
-    hardware_description = models.CharField(max_length=1000, blank=True, null=True)
+    media_composition = models.CharField(max_length=1000, default='')
+    hardware_description = models.CharField(max_length=1000, default='')
     # Subject to removal
     # image = models.ImageField(upload_to="configuration",null=True, blank=True)
 
@@ -547,7 +505,7 @@ class StudyModel(models.Model):
     label = models.CharField(max_length=1)
     organ = models.ForeignKey(OrganModel)
     sequence_number = models.IntegerField()
-    output = models.CharField(max_length=20, blank=True, null=True)
+    output = models.CharField(max_length=20, default='')
     # Subject to change
     integration_mode = models.CharField(max_length=13, choices=(('0', 'Not Connected'),('1','Connected')))
 
@@ -577,7 +535,7 @@ class AssayRun(RestrictedModel):
     start_date = models.DateField(help_text='YYYY-MM-DD')
     assay_run_id = models.TextField(unique=True, verbose_name='Study ID',
                                     help_text="Standard format 'CenterID-YYYY-MM-DD-Name-###'")
-    description = models.TextField(blank=True, null=True)
+    description = models.TextField(default='')
 
     file = models.FileField(upload_to='csv', verbose_name='Batch Data File',
                             blank=True, null=True, help_text='Do not upload until you have made each Chip Readout')
@@ -633,7 +591,7 @@ class AssayChipCells(models.Model):
                                                         ('ML', 'cells / mL'),
                                                         ('MM', 'cells / mm^2')))
     cell_passage = models.CharField(max_length=16,verbose_name='Passage#',
-                                    blank=True, null=True)
+                                    default='')
 
 
 class AssayChipSetup(FlaggableModel):
@@ -648,7 +606,7 @@ class AssayChipSetup(FlaggableModel):
     setup_date = models.DateField(help_text='YYYY-MM-DD')
     device = models.ForeignKey(OrganModel, verbose_name = 'Organ Model Name')
 
-    variance = models.CharField(max_length=3000, verbose_name='Variance from Protocol', null=True, blank=True)
+    variance = models.CharField(max_length=3000, verbose_name='Variance from Protocol', default='')
 
     # the unique chip identifier
     # can be a barcode or a hand written identifier
@@ -664,10 +622,10 @@ class AssayChipSetup(FlaggableModel):
                              verbose_name='conc. Unit',
                              null=True, blank=True)
 
-    scientist = models.CharField(max_length=100, blank=True, null=True)
-    notebook = models.CharField(max_length=256, blank=True, null=True)
+    scientist = models.CharField(max_length=100, default='')
+    notebook = models.CharField(max_length=256, default='')
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, blank=True, null=True)
+    notes = models.CharField(max_length=2048, default='')
 
     def __unicode__(self):
         return u'Chip-{}:{}({}{})'.format(self.assay_chip_id,
@@ -721,10 +679,10 @@ class AssayChipReadout(FlaggableModel):
 
     readout_start_time = models.DateField(verbose_name='Readout Start Date', help_text="YYYY-MM-DD")
 
-    notebook = models.CharField(max_length=256, blank=True, null=True)
+    notebook = models.CharField(max_length=256, default='')
     notebook_page = models.IntegerField(blank=True, null=True)
-    notes = models.CharField(max_length=2048, blank=True, null=True)
-    scientist = models.CharField(max_length=100, blank=True, null=True)
+    notes = models.CharField(max_length=2048, default='')
+    scientist = models.CharField(max_length=100, default='')
     file = models.FileField(upload_to='csv', verbose_name='Data File',
                             blank=True, null=True, help_text='Green = Data from database;'
                                                              ' Red = Line that will not be read'
@@ -820,9 +778,7 @@ class AssayChipResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity',
-                                blank=True,
-                                null=True)
+                                verbose_name='Severity')
 
     result_type = models.ForeignKey(AssayResultType,
                                     blank=True,

--- a/assays/models.py
+++ b/assays/models.py
@@ -59,23 +59,23 @@ class PhysicalUnits(LockableModel):
 
 
 # TODO TIME UNITS ARE SLATED FOR REMOVAL
-class TimeUnits(LockableModel):
-    """
-    Time Units (minutes, hours, etc)
-    """
-
-    unit = models.CharField(max_length=16)
-    description = models.CharField(max_length=256,
-                                   blank=True, null=True)
-    unit_order = models.FloatField(verbose_name='Seconds', default=0)
-
-    # this meta class is used to avoid a double 's' on the model name
-    class Meta(object):
-        verbose_name_plural = 'Time Units'
-        ordering = ['unit_order']
-
-    def __unicode__(self):
-        return self.unit
+#class TimeUnits(LockableModel):
+#    """
+#    Time Units (minutes, hours, etc)
+#    """
+#
+#    unit = models.CharField(max_length=16)
+#    description = models.CharField(max_length=256,
+#                                   blank=True, null=True)
+#    unit_order = models.FloatField(verbose_name='Seconds', default=0)
+#
+#    # this meta class is used to avoid a double 's' on the model name
+#    class Meta(object):
+#        verbose_name_plural = 'Time Units'
+#        ordering = ['unit_order']
+#
+#    def __unicode__(self):
+#        return self.unit
 
 
 class AssayModelType(LockableModel):
@@ -360,19 +360,19 @@ class AssayReadout(models.Model):
     elapsed_time = models.FloatField(default=0)
 
 
-class ReadoutUnit(LockableModel):
-    """
-    Units specific to readouts (AU, RFU, so on)
-    """
-
-    class Meta(object):
-        ordering = ('readout_unit',)
-
-    readout_unit = models.CharField(max_length=512,unique=True)
-    description = models.CharField(max_length=512,blank=True,null=True)
-
-    def __unicode__(self):
-        return self.readout_unit
+#class ReadoutUnit(LockableModel):
+#    """
+#    Units specific to readouts (AU, RFU, so on)
+#    """
+#
+#    class Meta(object):
+#        ordering = ('readout_unit',)
+#
+#    readout_unit = models.CharField(max_length=512,unique=True)
+#    description = models.CharField(max_length=512,blank=True,null=True)
+#
+#    def __unicode__(self):
+#        return self.readout_unit
 
 
 class AssayPlateReadout(FlaggableModel):

--- a/assays/static/assays/customize_configuration.js
+++ b/assays/static/assays/customize_configuration.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
 
             var source = data[i];
 
-            var outputs = source.output;
+            var outputs = source.output.split('-');
 
             for (var j=0; j < data.length; j++) {
 

--- a/assays/static/assays/customize_configuration.js
+++ b/assays/static/assays/customize_configuration.js
@@ -127,6 +127,7 @@ $(document).ready(function () {
             .data(bilinks)
             .enter().append("path")
             .attr("class", "link")
+            .style("stroke-width", 3)
             .style('stroke', function(d) { return d[3] ? '#00FF00':'#FF0000' })
             .style("marker-end", function(d) { return ms_ie ? "":'url(#arrow)' });
 
@@ -140,10 +141,10 @@ $(document).ready(function () {
 
         var node = gnodes.append("circle")
             .attr("class", "node")
-            .attr("r", 9)
+            .attr("r", 18)
             .style("fill", '#FDF5E6')
             .style("stroke", function(d) { return color(d.organ); })
-            .style("stroke-width", 1.5);
+            .style("stroke-width", 3);
 
         //Titles for hovering
         gnodes.append("title")
@@ -157,6 +158,7 @@ $(document).ready(function () {
             // otherwise the bottom of the text is centered, not the text itself
             .attr("dy", ".35em")
             .attr("text-anchor", "middle")
+            .attr("font-size", 20)
             .text(function(d) { return d.label; });
 
         force.on("tick", function() {
@@ -179,7 +181,7 @@ $(document).ready(function () {
             .attr("id", function(d) { return d; })
             // It is possible that the negative value in this viewBox breaks IE
             .attr("viewBox", "0 -5 10 10")
-            .attr("refX", 25)
+            .attr("refX", 20)
             .attr("refY", 0)
             .attr("markerWidth", 10)
             .attr("markerHeight", 6)

--- a/bioactivities/admin.py
+++ b/bioactivities/admin.py
@@ -163,7 +163,7 @@ class AssayAdmin(LockableAdmin):
     save_on_top = True
     list_per_page = 300
     list_display = (
-        'description', 'chembl_link', 'pubchem_id', 'organism', 'assay_type', 'locked')
+        'description', 'chembl_link', 'pubchem_id', 'organism', 'target', 'assay_type', 'locked')
     list_filter = ('assay_type',)
     search_fields = ['description', '=chemblid', 'pubchem_id']
     actions = ['update_fields']

--- a/bioactivities/admin.py
+++ b/bioactivities/admin.py
@@ -36,7 +36,7 @@ class TargetAdmin(LockableAdmin):
     list_per_page = 300
     list_display = ('name', 'organism', 'target_type', 'chembl_link', 'locked')
     list_filter = ('target_type', 'organism')
-    search_fields = ['name', 'organism', 'synonyms', '=chemblid']
+    search_fields = ['name', 'organism', 'synonyms', '=chemblid', 'GI']
     actions = ['update_fields']
     readonly_fields = ('last_update', 'created_by', 'created_on',
                        'modified_by', 'modified_on')
@@ -53,6 +53,7 @@ class TargetAdmin(LockableAdmin):
                     'organism',
                     'uniprot_accession',
                     'target_type',
+                    'GI'
                     'last_update',
                 )
             }
@@ -162,9 +163,9 @@ class AssayAdmin(LockableAdmin):
     save_on_top = True
     list_per_page = 300
     list_display = (
-        'description', 'chembl_link', 'organism', 'assay_type', 'locked')
+        'description', 'chembl_link', 'pubchem_id', 'organism', 'assay_type', 'locked')
     list_filter = ('assay_type',)
-    search_fields = ['description', '=chemblid']
+    search_fields = ['description', '=chemblid', 'pubchem_id']
     actions = ['update_fields']
     readonly_fields = ('last_update', 'created_by', 'created_on',
                        'modified_by', 'modified_on')
@@ -174,6 +175,10 @@ class AssayAdmin(LockableAdmin):
             None, {
                 'fields': (
                     'chemblid',
+                    'pubchem_id',
+                    ('source', 'source_id',),
+                    'name',
+                    'target',
                     'description',
                     'assay_type',
                     'organism',

--- a/bioactivities/admin.py
+++ b/bioactivities/admin.py
@@ -163,7 +163,7 @@ class AssayAdmin(LockableAdmin):
     list_per_page = 300
     list_display = (
         'description', 'chembl_link', 'organism', 'assay_type', 'locked')
-    list_filter = ('assay_type', 'organism')
+    list_filter = ('assay_type',)
     search_fields = ['description', '=chemblid']
     actions = ['update_fields']
     readonly_fields = ('last_update', 'created_by', 'created_on',
@@ -308,7 +308,6 @@ class BioactivityAdmin(LockableAdmin):
         'standardized_units',
         'chembl_link',
         'bioactivity_type',
-        'chembl_assay_type',
         'value',
         'units',
         'locked'
@@ -321,7 +320,7 @@ class BioactivityAdmin(LockableAdmin):
     fieldsets = (
         (None, {
             'fields': (('compound', 'assay'), 'bioactivity_display', ('target', 'target_confidence'),
-                       ('bioactivity_type', 'chembl_assay_type', 'value', 'units'),
+                       ('bioactivity_type', 'value', 'units'),
                        ('standard_name', 'standardized_value', 'standardized_units'),
                        ('activity_comment', 'reference', 'name_in_reference'), 'locked',
                        ('created_by', 'created_on'), ('modified_by', 'modified_on'),
@@ -422,60 +421,60 @@ class PubChemBioactivityAdmin(LockableAdmin):
 admin.site.register(PubChemBioactivity, PubChemBioactivityAdmin)
 
 
-class PubChemTargetAdmin(LockableAdmin):
-    search_fields = ['name', 'organism', 'GI']
-
-    save_on_top = True
-    list_per_page = 50
-
-    list_display = (
-        'name',
-        'organism',
-        'GI',
-    )
-
-    fieldsets = (
-        (None, {
-            'fields': (
-                'name',
-                'organism',
-                'GI',
-            )
-        }),
-    )
-
-
-admin.site.register(PubChemTarget, PubChemTargetAdmin)
-
-
-class PubChemAssayAdmin(LockableAdmin):
-    search_fields = ['aid', 'name', 'source']
-
-    save_on_top = True
-    list_per_page = 50
-
-    list_display = (
-        'aid',
-        'name',
-        'target_type',
-        'organism',
-        'source',
-        'source_id'
-    )
-
-    fieldsets = (
-        (None, {
-            'fields': (
-                'aid',
-                'name',
-                'target_type',
-                'organism',
-                'source',
-                'description',
-                'source_id'
-            )
-        }),
-    )
+#class PubChemTargetAdmin(LockableAdmin):
+#    search_fields = ['name', 'organism', 'GI']
+#
+#    save_on_top = True
+#    list_per_page = 50
+#
+#    list_display = (
+#        'name',
+#        'organism',
+#        'GI',
+#    )
+#
+#    fieldsets = (
+#        (None, {
+#            'fields': (
+#                'name',
+#                'organism',
+#                'GI',
+#            )
+#        }),
+#    )
+#
+#
+#admin.site.register(PubChemTarget, PubChemTargetAdmin)
 
 
-admin.site.register(PubChemAssay, PubChemAssayAdmin)
+#class PubChemAssayAdmin(LockableAdmin):
+#    search_fields = ['aid', 'name', 'source']
+#
+#    save_on_top = True
+#    list_per_page = 50
+#
+#    list_display = (
+#        'aid',
+#        'name',
+#        'target_type',
+#        'organism',
+#        'source',
+#        'source_id'
+#    )
+#
+#    fieldsets = (
+#        (None, {
+#            'fields': (
+#                'aid',
+#                'name',
+#                'target_type',
+#                'organism',
+#                'source',
+#                'description',
+#                'source_id'
+#            )
+#        }),
+#    )
+#
+#
+#admin.site.register(PubChemAssay, PubChemAssayAdmin)

--- a/bioactivities/admin.py
+++ b/bioactivities/admin.py
@@ -397,7 +397,7 @@ class PubChemBioactivityAdmin(LockableAdmin):
     search_fields = ['compound__name', 'activity_name', 'target__name']
     list_filter = ['compound', ]
 
-    raw_id_fields = ("target",)
+    raw_id_fields = ("target",'assay')
 
     save_on_top = True
     list_per_page = 50
@@ -406,7 +406,7 @@ class PubChemBioactivityAdmin(LockableAdmin):
         'compound',
         'activity_name',
         'value',
-        'target',
+        'normalized_value',
         'assay'
     )
 
@@ -416,6 +416,7 @@ class PubChemBioactivityAdmin(LockableAdmin):
                 'compound',
                 'target',
                 'value',
+                'normalized_value',
                 'activity_name',
                 'assay'
             )

--- a/bioactivities/admin.py
+++ b/bioactivities/admin.py
@@ -34,7 +34,7 @@ class TargetAdmin(LockableAdmin):
 
     save_on_top = True
     list_per_page = 300
-    list_display = ('name', 'organism', 'target_type', 'chembl_link', 'locked')
+    list_display = ('name', 'organism', 'target_type', 'chembl_link', 'GI', 'locked')
     list_filter = ('target_type', 'organism')
     search_fields = ['name', 'organism', 'synonyms', '=chemblid', 'GI']
     actions = ['update_fields']
@@ -394,7 +394,7 @@ admin.site.register(BioactivityType, BioactivityTypeAdmin)
 
 
 class PubChemBioactivityAdmin(LockableAdmin):
-    search_fields = ['compound__name', 'activity_name', 'target__name']
+    search_fields = ['compound__name', 'activity_name', 'target__name', 'outcome']
     list_filter = ['compound', ]
 
     raw_id_fields = ("target",'assay')
@@ -406,6 +406,7 @@ class PubChemBioactivityAdmin(LockableAdmin):
         'compound',
         'activity_name',
         'value',
+        'outcome',
         'normalized_value',
         'assay'
     )
@@ -416,6 +417,7 @@ class PubChemBioactivityAdmin(LockableAdmin):
                 'compound',
                 'target',
                 'value',
+                'outcome',
                 'normalized_value',
                 'activity_name',
                 'assay'

--- a/bioactivities/models.py
+++ b/bioactivities/models.py
@@ -223,6 +223,8 @@ class PubChemBioactivity(LockableModel):
     # Value is required
     value = models.FloatField(verbose_name="Value (uM)")
 
+    outcome = models.TextField(default='', verbose_name="Bioactivity Outcome")
+
     # Not required?
     # TODO Consider making this a FK to bioactivity types
     # TODO Or, perhaps we should make another table for PubChem types?

--- a/bioactivities/models.py
+++ b/bioactivities/models.py
@@ -47,27 +47,25 @@ def chembl_assay(chemblid):
 
 
 class Target(LockableModel):
-    # compound_id = AutoField(primary_key=True)
-    name = models.TextField(default='', help_text="Preferred target name.")
-    synonyms = models.TextField(default='')
+    name = models.TextField(help_text="Preferred target name.")
+    synonyms = models.TextField(null=True, blank=True)
 
     # external identifiers, not unique because does go with null on SQL server
     chemblid = models.TextField('ChEMBL ID',
-                                default='',
+                                null=True, blank=True,
                                 help_text="Enter a ChEMBL id, e.g. CHEMBL260, "
                                           "and click Retrieve to get target "
                                           "information automatically.")
 
-    description = models.TextField(default='')
+    description = models.TextField(null=True, blank=True)
 
-    gene_names = models.TextField(default='')
+    gene_names = models.TextField(null=True, blank=True)
 
-    organism = models.TextField(default='')
+    organism = models.TextField(null=True, blank=True)
 
-    uniprot_accession = models.TextField(default='')
+    uniprot_accession = models.TextField(null=True, blank=True)
 
-    # Without a ChEMBL link, I think it is fair to assume the target_type is single protein
-    target_type = models.TextField(default='')
+    target_type = models.TextField(null=True, blank=True)
 
     # NCBI identifier for protein/gene targets
     GI = models.TextField('NCBI GI',
@@ -108,11 +106,11 @@ class Assay(LockableModel):
                                           "to get target information "
                                           "automatically.")
 
-    description = models.TextField(default='')
-    organism = models.TextField(default='')
-    assay_type = models.CharField(max_length=1, default='U', choices=ASSAYTYPES)
-    journal = models.TextField(default='')
-    strain = models.TextField(default='')
+    description = models.TextField(default='',)
+    organism = models.TextField(default='',)
+    assay_type = models.CharField(max_length=1, choices=ASSAYTYPES, default='U')
+    journal = models.TextField(default='',)
+    strain = models.TextField(default='',)
 
     pubchem_id = models.TextField('PubChem ID', default='')
     source = models.TextField(default='')
@@ -161,23 +159,24 @@ class Bioactivity(LockableModel):
     target = models.ForeignKey(Target)
     target_confidence = models.IntegerField(blank=True, null=True)
 
-    bioactivity_type = models.TextField(verbose_name="name", default='')
+    bioactivity_type = models.TextField(verbose_name="name", blank=True, null=True)
 
-    standard_name = models.TextField(default='')
-    operator = models.TextField(default='')
+    standard_name = models.TextField(blank=True, null=True)
+    operator = models.TextField(blank=True, null=True)
 
-    units = models.TextField(default='')
+    units = models.TextField(blank=True, null=True)
     value = models.FloatField(blank=True, null=True)
 
     standardized_units = models.TextField(verbose_name="std units",
-                                          default='')
+                                          blank=True,
+                                          null=True)
     standardized_value = models.FloatField(verbose_name="std vals",
                                            blank=True,
                                            null=True)
 
-    activity_comment = models.TextField(default='')
-    reference = models.TextField(default='')
-    name_in_reference = models.TextField(default='')
+    activity_comment = models.TextField(blank=True, null=True)
+    reference = models.TextField(blank=True, null=True)
+    name_in_reference = models.TextField(blank=True, null=True)
 
     # Use ChEMBL Assay Type to clarify unclear names like "Activity"
     # Removed for now

--- a/bioactivities/models.py
+++ b/bioactivities/models.py
@@ -48,25 +48,30 @@ def chembl_assay(chemblid):
 
 class Target(LockableModel):
     # compound_id = AutoField(primary_key=True)
-    name = models.TextField(help_text="Preferred target name.")
-    synonyms = models.TextField(null=True, blank=True)
+    name = models.TextField(default='', help_text="Preferred target name.")
+    synonyms = models.TextField(default='')
 
     # external identifiers, not unique because does go with null on SQL server
     chemblid = models.TextField('ChEMBL ID',
-                                null=True, blank=True, unique=True,
+                                default='',
                                 help_text="Enter a ChEMBL id, e.g. CHEMBL260, "
                                           "and click Retrieve to get target "
                                           "information automatically.")
 
-    description = models.TextField(null=True, blank=True)
+    description = models.TextField(default='')
 
-    gene_names = models.TextField(null=True, blank=True)
+    gene_names = models.TextField(default='')
 
-    organism = models.TextField(null=True, blank=True)
+    organism = models.TextField(default='')
 
-    uniprot_accession = models.TextField(null=True, blank=True)
+    uniprot_accession = models.TextField(default='')
 
-    target_type = models.TextField(null=True, blank=True)
+    # Without a ChEMBL link, I think it is fair to assume the target_type is single protein
+    target_type = models.TextField(default='')
+
+    # NCBI identifier for protein/gene targets
+    GI = models.TextField('NCBI GI',
+                          default='')
 
     last_update = models.DateField(blank=True, null=True,
                                    help_text="Last time when activities "
@@ -92,23 +97,29 @@ class Target(LockableModel):
     chembl_link.short_description = 'ChEMBL ID'
 
 
-ASSAYTYPES = (('B', 'Binding'), ('F', 'Functional'), ('A', 'ADMET'))
-
+ASSAYTYPES = (('B', 'Binding'), ('F', 'Functional'), ('A', 'ADMET'), ('P', 'Physicochemical'), ('U', 'Unknown'))
 
 class Assay(LockableModel):
     # external identifiers, not unique because does go with null on SQL server
     chemblid = models.TextField('ChEMBL ID',
-                                null=True, blank=True, unique=True,
+                                default='',
                                 help_text="Enter a ChEMBL id, e.g. "
                                           "CHEMBL1217643, and click Retrieve "
                                           "to get target information "
                                           "automatically.")
 
-    description = models.TextField(blank=True, null=True)
-    organism = models.TextField(blank=True, null=True)
-    assay_type = models.CharField(max_length=1, choices=ASSAYTYPES)
-    journal = models.TextField(blank=True, null=True)
-    strain = models.TextField(blank=True, null=True)
+    description = models.TextField(default='')
+    organism = models.TextField(default='')
+    assay_type = models.CharField(max_length=1, default='U', choices=ASSAYTYPES)
+    journal = models.TextField(default='')
+    strain = models.TextField(default='')
+
+    pubchem_id = models.TextField('PubChem ID', default='')
+    source = models.TextField(default='')
+    source_id = models.TextField(default='')
+    name = models.TextField(default='', verbose_name="Assay Name")
+
+    target = models.ForeignKey('Target', default=None, verbose_name="Target", null=True, blank=True)
 
     last_update = models.DateField(blank=True, null=True,
                                    help_text="Last time when activities "
@@ -145,30 +156,32 @@ class Bioactivity(LockableModel):
                                  related_name='bioactivity_compound')
     parent_compound = models.ForeignKey('compounds.Compound',
                                         related_name='bioactivity_parent')
+
+    # Target is slated to be added to assay instead
     target = models.ForeignKey(Target)
     target_confidence = models.IntegerField(blank=True, null=True)
 
-    bioactivity_type = models.TextField(verbose_name="name", blank=True, null=True)
+    bioactivity_type = models.TextField(verbose_name="name", default='')
 
-    standard_name = models.TextField(blank=True, null=True)
-    operator = models.TextField(blank=True, null=True)
+    standard_name = models.TextField(default='')
+    operator = models.TextField(default='')
 
-    units = models.TextField(blank=True, null=True)
+    units = models.TextField(default='')
     value = models.FloatField(blank=True, null=True)
 
     standardized_units = models.TextField(verbose_name="std units",
-                                          blank=True,
-                                          null=True)
+                                          default='')
     standardized_value = models.FloatField(verbose_name="std vals",
                                            blank=True,
                                            null=True)
 
-    activity_comment = models.TextField(blank=True, null=True)
-    reference = models.TextField(blank=True, null=True)
-    name_in_reference = models.TextField(blank=True, null=True)
+    activity_comment = models.TextField(default='')
+    reference = models.TextField(default='')
+    name_in_reference = models.TextField(default='')
 
     # Use ChEMBL Assay Type to clarify unclear names like "Activity"
-    chembl_assay_type = models.TextField(blank=True, null=True, default='')
+    # Removed for now
+    # chembl_assay_type = models.TextField(blank=True, null=True, default='')
 
     def organism(self):
         return self.target.organism
@@ -199,15 +212,14 @@ class BioactivityType(LockableModel):
 
 class PubChemBioactivity(LockableModel):
     # TextFields and CharFields have no performace benefits over eachother, but may want to use CharFields for clarity
-    assay = models.ForeignKey('PubChemAssay', blank=True, null=True)
+    assay = models.ForeignKey('Assay', blank=True, null=True)
 
     # It makes sense just to add the PubChem CID to the compound then just use a FK
     #compound_id = models.TextField(verbose_name="Compound ID")
     compound = models.ForeignKey('compounds.Compound')
 
-    # May eventually make a table for PubChem targets
-    # In such an instance, change this to a FK
-    target = models.ForeignKey('PubChemTarget', default=None, verbose_name="Target", null=True, blank=True)
+    # Target is slated to be added to assay instead
+    target = models.ForeignKey('Target', default=None, verbose_name="Target", null=True, blank=True)
 
     # Value is required
     value = models.FloatField(verbose_name="Value (uM)")
@@ -217,6 +229,12 @@ class PubChemBioactivity(LockableModel):
     # TODO Or, perhaps we should make another table for PubChem types?
     activity_name = models.TextField(default='', verbose_name="Activity Name")
 
+    # Normalized value for visualization and so on
+    # Be sure to normalize on bioactivity-target pair across the entire database
+    normalized_value = models.FloatField(blank=True,
+                                        null=True,
+                                        verbose_name="Value (uM)")
+
 
 # TODO PubChem Bioactivity Type? and PubChem targets
 # To following table may eventually be merged into the existing bioactivty type table
@@ -225,42 +243,43 @@ class PubChemBioactivity(LockableModel):
 #    name = models.TextField(default='')
 
 
-# Apparently all PubChem targets are Single Proteins (or at least point to a specific gene)
+# TODO PubChemTarget model is slated for removal
 class PubChemTarget(LockableModel):
     name = models.TextField(default='', help_text="Preferred target name.")
-
-    # Species will likely be useful to have
-    organism = models.TextField(default='')
 
     # May be difficult to acquire
     #synonyms = models.TextField(null=True, blank=True)
 
     # The GI is what is given by a PubChem assay
-    GI = models.TextField('NCBI GI')
+    # Optional, not all targets will have this
+    GI = models.TextField('NCBI GI',
+                          null=True,
+                          blank=True)
+
+    # Target type is not always listed: not required
+    target_type = models.TextField(default='')
+
+    # Organism is not always listed: not required
+    organism = models.TextField(default='')
 
     def __unicode__(self):
         return unicode(self.name)
 
 
+# TODO PubChemAssay model is slated for removal
 class PubChemAssay(LockableModel):
     # Source is an optional field showing where PubChem pulled their data
-    source = models.TextField(default='', blank=True, null=True)
+    source = models.TextField(default='')
 
-    source_id = models.TextField(default='', blank=True, null=True)
-
-    # Target type is not always listed: not required
-    target_type = models.TextField(default='', blank=True, null=True)
-
-    # Organism is not always listed: not required
-    organism = models.TextField(default='', blank=True, null=True)
+    source_id = models.TextField(default='')
 
     # PubChem ID
     aid = models.TextField(verbose_name="Assay ID")
 
     # Not required?
-    name = models.TextField(default='', verbose_name="Assay Name", null=True, blank=True)
+    name = models.TextField(default='', verbose_name="Assay Name")
 
-    description = models.TextField(blank=True, null=True)
+    description = models.TextField(default='')
 
     def __unicode__(self):
         return unicode(self.aid)

--- a/bioactivities/parsers.py
+++ b/bioactivities/parsers.py
@@ -15,7 +15,7 @@ import scipy.cluster
 import numpy as np
 
 from compounds.models import Compound
-from .models import Bioactivity
+from .models import Bioactivity, PubChemBioactivity, Assay
 from drugtrials.models import FindingResult
 
 from django.core import serializers
@@ -59,67 +59,73 @@ def generate_list_of_all_data_in_bioactivities(organisms, targets):
     return result
 
 def generate_list_of_all_bioactivities_in_bioactivities():
-    cursor = connection.cursor()
-
-    # Note that this query does not exclude all negative standardized_values
-    # This is the case because it selects ONLY THE NAMES of bioactivities
-    # If a bioactivity name is associated with both positive and negative values, those negative values will be included
-    cursor.execute(
-        'SELECT bioactivities_bioactivity.standard_name '
-        'FROM bioactivities_bioactivity '
-        'WHERE bioactivities_bioactivity.standardized_value>0;'
-    )
-
-    result = generate_record_frequency_data(cursor.fetchall())
-    cursor.close()
-
+    pubchem_bioactivities = PubChemBioactivity.objects.all().values_list('activity_name')
+    result = generate_record_frequency_data(pubchem_bioactivities)
     return result
+    #cursor = connection.cursor()
+
+    ## Note that this query does not exclude all negative standardized_values
+    ## This is the case because it selects ONLY THE NAMES of bioactivities
+    ## If a bioactivity name is associated with both positive and negative values, those negative values will be included
+    #cursor.execute(
+        #'SELECT bioactivities_bioactivity.standard_name '
+        #'FROM bioactivities_bioactivity '
+        #'WHERE bioactivities_bioactivity.standardized_value>0;'
+    #)
+
+    #result = generate_record_frequency_data(cursor.fetchall())
+    #cursor.close()
+
+    #return result
 
 
 def generate_list_of_all_targets_in_bioactivities(organisms, targets):
-
-    cursor = connection.cursor()
-
-
-    where_clause = " WHERE ( "
-    organisms_clause = ""
-
-    if not organisms or not targets:
-        return
-
-    if len(organisms) is 1:
-        organisms_clause = "   LOWER(bioactivities_target.organism)=LOWER('{}') ".format(''.join(organisms))
-    else:
-        for organism in organisms:
-            organisms_clause += "OR LOWER(bioactivities_target.organism)=LOWER('{}') ".format(''.join(organism))
-
-    where_clause += organisms_clause[2:]  # remove the first 'OR'
-
-    where_clause += ") AND ("
-
-    targets_clause = ""
-
-    if len(targets) is 1:
-        targets_clause = "   LOWER(bioactivities_target.target_type)=LOWER('{}') ".format(''.join(targets))
-    else:
-        for target in targets:
-            targets_clause += "OR LOWER(bioactivities_target.target_type)=LOWER('{}') ".format(''.join(target))
-
-    where_clause += targets_clause[2:]  # remove the first 'OR'
-    where_clause += ");"
-
-    cursor.execute(
-        " SELECT bioactivities_target.name " +
-        " FROM bioactivities_bioactivity " +
-        " INNER JOIN bioactivities_target " +
-        " ON bioactivities_bioactivity.target_id=bioactivities_target.id " +
-        where_clause
-    )
-
-    result = generate_record_frequency_data(cursor.fetchall())
-    cursor.close()
-
+    pubchem_targets = Assay.objects.filter(
+        organism__in=organisms,
+        target__target_type__in=targets).values_list('target__name')
+    result = generate_record_frequency_data(pubchem_targets)
     return result
+    #cursor = connection.cursor()
+
+    #where_clause = " WHERE ( "
+    #organisms_clause = ""
+
+    #if not organisms or not targets:
+        #return
+
+    #if len(organisms) is 1:
+        #organisms_clause = "   LOWER(bioactivities_target.organism)=LOWER('{}') ".format(''.join(organisms))
+    #else:
+        #for organism in organisms:
+            #organisms_clause += "OR LOWER(bioactivities_target.organism)=LOWER('{}') ".format(''.join(organism))
+
+    #where_clause += organisms_clause[2:]  # remove the first 'OR'
+
+    #where_clause += ") AND ("
+
+    #targets_clause = ""
+
+    #if len(targets) is 1:
+        #targets_clause = "   LOWER(bioactivities_target.target_type)=LOWER('{}') ".format(''.join(targets))
+    #else:
+        #for target in targets:
+            #targets_clause += "OR LOWER(bioactivities_target.target_type)=LOWER('{}') ".format(''.join(target))
+
+    #where_clause += targets_clause[2:]  # remove the first 'OR'
+    #where_clause += ");"
+
+    #cursor.execute(
+        #" SELECT bioactivities_target.name " +
+        #" FROM bioactivities_bioactivity " +
+        #" INNER JOIN bioactivities_target " +
+        #" ON bioactivities_bioactivity.target_id=bioactivities_target.id " +
+        #where_clause
+    #)
+
+    #result = generate_record_frequency_data(cursor.fetchall())
+    #cursor.close()
+
+    #return result
 
 # Worry about filtering by organism later
 # FK for organism is a little odd right now
@@ -128,9 +134,9 @@ def generate_list_of_all_drugtrials(desired_organisms):
     # TODO
     # This requires refactoring, magic conversion tables are not good practice
     organisms = {
-        'Homo Sapiens': 'Human',
-        'Rattus Norvegicus': 'Rat',
-        'Canis Lupus Familiaris': 'Dog'
+        'Homo sapiens': 'Human',
+        'Rattus norvegicus': 'Rat',
+        'Canis lupus familiaris': 'Dog'
     }
 
     desired_organisms = [organisms.get(organism,'') for organism in desired_organisms]
@@ -155,102 +161,145 @@ def generate_list_of_all_drugtrials(desired_organisms):
     return result
 
 def generate_list_of_all_compounds_in_bioactivities():
-    cursor = connection.cursor()
-
-    cursor.execute(
-        'SELECT compounds_compound.name, compounds_compound.known_drug, compounds_compound.logp, compounds_compound.molecular_weight '
-        'FROM bioactivities_bioactivity '
-        'INNER JOIN compounds_compound '
-        'ON bioactivities_bioactivity.compound_id=compounds_compound.id;'
-    )
-
-    result = generate_record_frequency_data(cursor.fetchall())
-    cursor.close()
-
+    pubchem_compounds = PubChemBioactivity.objects.all().prefetch_related('compound').values_list('compound__name')
+    result = generate_record_frequency_data(pubchem_compounds)
     return result
+    #cursor = connection.cursor()
+
+    #cursor.execute(
+        #'SELECT compounds_compound.name, compounds_compound.known_drug, compounds_compound.logp, compounds_compound.molecular_weight '
+        #'FROM bioactivities_bioactivity '
+        #'INNER JOIN compounds_compound '
+        #'ON bioactivities_bioactivity.compound_id=compounds_compound.id;'
+    #)
+
+    #result = generate_record_frequency_data(cursor.fetchall())
+    #cursor.close()
+
+    #return result
 
 
 def fetch_all_standard_bioactivities_data(
         desired_compounds,
         desired_targets,
         desired_bioactivities,
+        desired_organisms,
         normalized,
         log_scale
 ):
-    # using values for now, FUTURE: use standardized_values
-    #Appears to be using standardized_values now
-    cursor = connection.cursor()
+    # First, we acquire all the filtered hits
+    filtered_bioactivities = PubChemBioactivity.objects.filter(assay__target__isnull=False)
+    filtered_bioactivities = filtered_bioactivities.filter(
+        compound__name__in=desired_compounds,
+        activity_name__in=desired_bioactivities,
+        assay__target__name__in=desired_targets).select_related('compound__name', 'assay__target__name')
 
-    # Please note that normalization now goes from 0.0001 to 1
-    cursor.execute(
-        'SELECT compound,target,tbl.bioactivity,AVG(value) as value,units,'
-        'AVG(norm_value) as norm_value,organism,target_type '
-        'FROM ( '
-        'SELECT compounds_compound.name as compound, '
-        'bioactivities_target.name as target, '
-        'bioactivities_bioactivity.standard_name as bioactivity, '
-        'bioactivities_bioactivity.standardized_value as value,bioactivities_bioactivity.standardized_units as units, '
-        'bioactivities_target.organism, '
-        'bioactivities_target.target_type,'
-        'CASE WHEN agg_tbl.max_value-agg_tbl.min_value <> 0 '
-        'THEN (0.9999)*((standardized_value-agg_tbl.min_value)/(agg_tbl.max_value-agg_tbl.min_value)) + 0.0001 ELSE 1 END as norm_value '
-        'FROM bioactivities_bioactivity '
-        'INNER JOIN compounds_compound '
-        'ON bioactivities_bioactivity.compound_id=compounds_compound.id '
-        'INNER JOIN bioactivities_target '
-        'ON bioactivities_bioactivity.target_id=bioactivities_target.id '
-        'INNER JOIN '
-        '(SELECT bioactivities_bioactivity.standard_name ,'
-        'MAX(standardized_value) as max_value,MIN(standardized_value) as min_value '
-        'FROM bioactivities_bioactivity '
-        'GROUP BY bioactivities_bioactivity.standard_name '
-        ') as agg_tbl ON bioactivities_bioactivity.standard_name = agg_tbl.standard_name '
-        ') as tbl '
-        ' GROUP BY compound,target,tbl.bioactivity,units,organism,target_type '
-        'HAVING AVG(value) IS NOT NULL ;'
-    )
+    # Then we can iterate over them to acquire the average values and so on
 
-    # bioactivity is a tuple:
-    # (compound name, target name, the bioactivity, value, units, norm_value,organism,target_type)
-    # (0            , 1          , 2              , 3 ,  4, 5, 6, 7   )
-    query = cursor.fetchall()
+    # This dictionary will take a tuple as a key (compound, target, bioactivity, organism)
+    # DON'T WORRY ABOUT UNITS AS EVERYTHING IS IN uM
+    bioactivities = {}
 
-    result = []
-
-    for q in query:
-
-        if q[0] not in desired_compounds:
-            continue
-        if q[1] not in desired_targets:
-            continue
-
-        if q[2] not in desired_bioactivities:
-            continue
-
-        value = q[3]
-
+    # Collect every value
+    for bio in filtered_bioactivities:
+        bio_key = (bio.compound.name, bio.assay.target.name, bio.activity_name, bio.assay.organism)
         if normalized:
-            value = q[5]
-
-        # Please note that negative and zero values ARE EXCLUDED
+            value = bio.normalized_value
+        else:
+            value = bio.value
         if log_scale:
-            if value <= 0:
-                continue
-
             value = np.log10(value)
+        if bio_key not in bioactivities:
+            bioactivities[bio_key] = [value]
+        else:
+            bioactivities[bio_key].append(value)
 
-        result.append(
-            {
-                'compound': q[0],
-                'target': q[1],
-                'bioactivity': q[2],
-                'value': value
-            }
-        )
+    results = []
 
-    cursor.close()
+    # Mean every list of values and build the dictionary of values to return
+    for bio_key in bioactivities:
+        bio_to_add = {}
+        bio_to_add['value'] = sum(bioactivities[bio_key])/float(len(bioactivities[bio_key]))
+        bio_to_add['compound'] = bio_key[0]
+        bio_to_add['target'] = bio_key[1]
+        bio_to_add['bioactivity'] = bio_key[2]
+        results.append(bio_to_add)
 
-    return result
+    return results
+    ## using values for now, FUTURE: use standardized_values
+    ##Appears to be using standardized_values now
+    #cursor = connection.cursor()
+
+    ## Please note that normalization now goes from 0.0001 to 1
+    #cursor.execute(
+        #'SELECT compound,target,tbl.bioactivity,AVG(value) as value,units,'
+        #'AVG(norm_value) as norm_value,organism,target_type '
+        #'FROM ( '
+        #'SELECT compounds_compound.name as compound, '
+        #'bioactivities_target.name as target, '
+        #'bioactivities_bioactivity.standard_name as bioactivity, '
+        #'bioactivities_bioactivity.standardized_value as value,bioactivities_bioactivity.standardized_units as units, '
+        #'bioactivities_target.organism, '
+        #'bioactivities_target.target_type,'
+        #'CASE WHEN agg_tbl.max_value-agg_tbl.min_value <> 0 '
+        #'THEN (0.9999)*((standardized_value-agg_tbl.min_value)/(agg_tbl.max_value-agg_tbl.min_value)) + 0.0001 ELSE 1 END as norm_value '
+        #'FROM bioactivities_bioactivity '
+        #'INNER JOIN compounds_compound '
+        #'ON bioactivities_bioactivity.compound_id=compounds_compound.id '
+        #'INNER JOIN bioactivities_target '
+        #'ON bioactivities_bioactivity.target_id=bioactivities_target.id '
+        #'INNER JOIN '
+        #'(SELECT bioactivities_bioactivity.standard_name ,'
+        #'MAX(standardized_value) as max_value,MIN(standardized_value) as min_value '
+        #'FROM bioactivities_bioactivity '
+        #'GROUP BY bioactivities_bioactivity.standard_name '
+        #') as agg_tbl ON bioactivities_bioactivity.standard_name = agg_tbl.standard_name '
+        #') as tbl '
+        #' GROUP BY compound,target,tbl.bioactivity,units,organism,target_type '
+        #'HAVING AVG(value) IS NOT NULL ;'
+    #)
+
+    ## bioactivity is a tuple:
+    ## (compound name, target name, the bioactivity, value, units, norm_value,organism,target_type)
+    ## (0            , 1          , 2              , 3 ,  4, 5, 6, 7   )
+    #query = cursor.fetchall()
+
+    #result = []
+
+    #for q in query:
+
+        #if q[0] not in desired_compounds:
+            #continue
+        #if q[1] not in desired_targets:
+            #continue
+
+        #if q[2] not in desired_bioactivities:
+            #continue
+
+        #value = q[3]
+
+        #if normalized:
+            #value = q[5]
+
+        ## Please note that negative and zero values ARE EXCLUDED
+        #if log_scale:
+            #if value <= 0:
+                #continue
+
+            #value = np.log10(value)
+
+        #result.append(
+            #{
+                #'compound': q[0],
+                #'target': q[1],
+                #'bioactivity': q[2],
+                #'value': value
+            #}
+        #)
+
+    #cursor.close()
+
+    #return result
 
 
 def fetch_all_standard_drugtrials_data(
@@ -264,9 +313,9 @@ def fetch_all_standard_drugtrials_data(
     # TODO
     # This requires refactoring, magic conversion tables are not good practice
     organisms = {
-        'Homo Sapiens': 'Human',
-        'Rattus Norvegicus': 'Rat',
-        'Canis Lupus Familiaris': 'Dog'
+        'Homo sapiens': 'Human',
+        'Rattus norvegicus': 'Rat',
+        'Canis lupus familiaris': 'Dog'
     }
 
     desired_organisms = [organisms.get(organism,'') for organism in desired_organisms]
@@ -461,6 +510,7 @@ def heatmap(request):
         desired_compounds,
         desired_targets,
         desired_bioactivities,
+        desired_organisms,
         normalized,
         log_scale
     )
@@ -492,7 +542,7 @@ def heatmap(request):
         unwound_data = pivoted_data.unstack().reset_index(name='value').dropna()
 
         unwound_data['target_bioactivity_pair'] = \
-            unwound_data['target'] + '_ ' + unwound_data['bioactivity']
+            unwound_data['target'] + '_' + unwound_data['bioactivity']
 
         del unwound_data['target']
         del unwound_data['bioactivity']
@@ -526,7 +576,7 @@ def heatmap(request):
         data_hash
     )
 
-    # string representation of the respective full full paths
+    # string representation of the respective full paths
     data_csv_fullpath = fullpath_without_extension + '_data.csv'
 
     # generate file handles for the csv writer
@@ -722,6 +772,7 @@ def cluster(request):
         desired_compounds,
         desired_targets,
         desired_bioactivities,
+        desired_organisms,
         normalized,
         log_scale
     )
@@ -987,10 +1038,6 @@ def cluster(request):
     #     'data_json': data_json_relpath
     # }
 
-# Function to adhere to organism naming convention
-def cap_first(string):
-    return string[0].upper() + string[1:].lower()
-
 def table(request):
     if len(request.body) == 0:
         return {'error': 'empty request body'}
@@ -1031,7 +1078,7 @@ def table(request):
     desired_target_types = [
         x.get(
             'name'
-        ).upper() for x in request_filter.get(
+        ) for x in request_filter.get(
             'target_types_filter'
         ) if x.get(
             'is_selected'
@@ -1039,9 +1086,9 @@ def table(request):
     ]
 
     desired_organisms = [
-        cap_first(x.get(
+        x.get(
             'name'
-        )) for x in request_filter.get(
+        ) for x in request_filter.get(
             'organisms_filter'
         ) if x.get(
             'is_selected'

--- a/bioactivities/parsers.py
+++ b/bioactivities/parsers.py
@@ -161,7 +161,7 @@ def generate_list_of_all_drugtrials(desired_organisms):
     return result
 
 def generate_list_of_all_compounds_in_bioactivities():
-    pubchem_compounds = PubChemBioactivity.objects.all().prefetch_related('compound').values_list('compound__name')
+    pubchem_compounds = PubChemBioactivity.objects.all().prefetch_related('compound').values_list('compound__name', 'compound__known_drug', 'compound__logp', 'compound__molecular_weight')
     result = generate_record_frequency_data(pubchem_compounds)
     return result
     #cursor = connection.cursor()

--- a/bioactivities/static/bioactivities/filter.js
+++ b/bioactivities/static/bioactivities/filter.js
@@ -110,13 +110,16 @@ $(document).ready(function () {
                 if (changed == 'all') {
                     // Clear bioactivities
                     reset_rows('bioactivities', bioactivities, '');
-                    
+
                     // Clear compounds
                     reset_rows('compounds', compounds, 'c');
 
                     // Clear drugtrials
                     reset_rows('drugtrials', drugtrials, '');
                 }
+
+                // Trigger compound filters
+                trigger_compound_filters();
 
                 // Enable everything
                 $(":input").prop("disabled", false);
@@ -402,8 +405,18 @@ $(document).ready(function () {
 
     // Special filtering for compounds
 
+    function trigger_compound_filters() {
+        drugs.trigger('change');
+        non_drugs.trigger('change');
+        logp.trigger('change');
+        molecular_weight.trigger('change');
+    }
+
+    var drugs = $('#drugs');
+    var non_drugs = $('#non_drugs');
+
     // Check to see if the "drugs" button has been clicked
-    $('#drugs').change(function (evt) {
+    drugs.change(function (evt) {
         // Show all drugs
         if (this.checked) {
             $("#compounds tr").each(function () {
@@ -430,7 +443,7 @@ $(document).ready(function () {
     });
 
     // Check to see if the "non-drugs" button has been clicked
-    $('#non_drugs').change(function (evt) {
+    non_drugs.change(function (evt) {
         // Show all non-drugs
         if (this.checked) {
             $("#compounds tr").each(function () {

--- a/bioactivities/static/bioactivities/filter.js
+++ b/bioactivities/static/bioactivities/filter.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
         $('#' + name).html('');
         // Add from list
         for (var i in list) {
-            var row = ''
+            var row = '';
             // Note added 'c' to avoid confusion with graphic
             if (add) {
                 var data = list[i].name.split('|');

--- a/bioactivities/static/bioactivities/filter.js
+++ b/bioactivities/static/bioactivities/filter.js
@@ -568,19 +568,4 @@ $(document).ready(function () {
             $('#selection').prop('hidden', true);
         }
     };
-//    function hashChange() {
-//
-//        if (document.location.hash == "") {
-//            $('#graphic').prop('hidden',true);
-//            $('#selection').prop('hidden',false)
-//        }
-//
-//        else {
-//            $('#graphic').prop('hidden',false);
-//            $('#selection').prop('hidden',true)
-//        }
-//    }
-//
-//    //This will call the hashchange function whenever the hashchanges (does not work on outdated versions of IE)
-//    window.onhashchange = hashChange;
 });

--- a/bioactivities/static/bioactivities/filter.js
+++ b/bioactivities/static/bioactivities/filter.js
@@ -294,18 +294,6 @@ $(document).ready(function () {
 
     refresh('all');
 
-    // Return to selection
-    $('#back').click(function (evt) {
-        $('#graphic').prop('hidden', true);
-        $('#selection').prop('hidden', false);
-//        document.location.hash = "";
-//        //Why does microsoft want me to suffer?
-//        if (browser.isIE && browser.verIE >= 11) {
-//            $('#graphic').prop('hidden',true);
-//            $('#selection').prop('hidden',false)
-//        }
-    });
-
     var bioactivity_search = $('#bioactivity_filter');
     var target_search = $('#target_filter');
     var compound_search = $('#compound_filter');
@@ -570,6 +558,16 @@ $(document).ready(function () {
         molecular_weight.trigger('change');
     });
 
+    window.onhashchange = function() {
+        if (location.hash != '#show') {
+            $('#graphic').prop('hidden', true);
+            $('#selection').prop('hidden', false);
+        }
+        else {
+            $('#graphic').prop('hidden', false);
+            $('#selection').prop('hidden', true);
+        }
+    };
 //    function hashChange() {
 //
 //        if (document.location.hash == "") {

--- a/bioactivities/static/bioactivities/table.js
+++ b/bioactivities/static/bioactivities/table.js
@@ -21,11 +21,12 @@ $(document).ready(function () {
             row += "<td><a href='/compounds/"+bio.compoundid+"'>" + bio.compound + "</a></td>";
             row += "<td>" + bio.target + "</td>";
             row += "<td>" + bio.organism + "</td>";
-            row += "<td>" + bio.standard_name + "</td>";
-            row += "<td>" + bio.operator + "</td>";
+            row += "<td>" + bio.activity_name + "</td>";
+            //row += "<td>" + bio.operator + "</td>";
             row += "<td>" + bio.standardized_value + "</td>";
-            row += "<td>" + bio.standardized_units + "</td>";
+            //row += "<td>" + bio.standardized_units + "</td>";
             row += "<td><a href='https://www.ebi.ac.uk/chembl/assay/inspect/"+bio.chemblid+"'>" + bio.chemblid + "</a></td>";
+            row += "<td><a href='https://pubchem.ncbi.nlm.nih.gov/assay/assay.cgi?aid="+bio.pubchem_id+"'>" + bio.pubchem_id + "</a></td>";
 //            row += "<td>" + bio.bioactivity_type + "</td>";
 //            row += "<td>" + bio.value + "</td>";
 //            row += "<td>" + bio.units + "</td>";

--- a/bioactivities/views.py
+++ b/bioactivities/views.py
@@ -56,9 +56,8 @@ def bioactivities_list(request):
             else:
                 data = Bioactivity.objects.filter(standard_name__isnull=False,
                                               standardized_units__isnull=False,
-                                              standardized_value__isnull=False).prefetch_related('compound',
-                                                                                                 'target',
-                                                                                                 'created_by').select_related('assay__chemblid')
+                                              standardized_value__isnull=False).select_related('compound__name',
+                                                                                                 'target__name','assay__chemblid')
 
             if compound:
                 data = data.filter(compound__name__icontains=compound)
@@ -74,7 +73,7 @@ def bioactivities_list(request):
 
             if exclude_targetless:
                 # Exclude where target is "Unchecked"
-                data = data.filter(assay__target__isnull=False).exclude(target__name="Unchecked").exclude(target__name='')
+                data = data.filter(assay__target__isnull=False).exclude(assay__target__name="Unchecked").exclude(assay__target__name='')
 
             if exclude_organismless:
                 # Exclude where assay and target organism are null

--- a/bioactivities/views.py
+++ b/bioactivities/views.py
@@ -52,7 +52,7 @@ def bioactivities_list(request):
         # I might want to sort by multiple fields later
         if any([compound,target,name]):
             if pubchem:
-                data = PubChemBioactivity.objects.all().prefetch_related('compound','target').select_related('assay__aid')
+                data = PubChemBioactivity.objects.all().select_related('compound__name','assay__target','assay__pubchem_id')
             else:
                 data = Bioactivity.objects.filter(standard_name__isnull=False,
                                               standardized_units__isnull=False,
@@ -64,7 +64,7 @@ def bioactivities_list(request):
                 data = data.filter(compound__name__icontains=compound)
 
             if target:
-                data = data.filter(target__name__icontains=target)
+                data = data.filter(assay__target__name__icontains=target)
 
             if name:
                 if pubchem:
@@ -74,13 +74,14 @@ def bioactivities_list(request):
 
             if exclude_targetless:
                 # Exclude where target is "Unchecked"
-                data = data.filter(target__isnull=False).exclude(target__name="Unchecked")
+                data = data.filter(assay__target__isnull=False).exclude(target__name="Unchecked").exclude(target__name='')
 
             if exclude_organismless:
                 # Exclude where assay and target organism are null
-                data = data.filter(assay__organism__isnull=False) | data.filter(target__organism__isnull=False)
+                # TODO JUST SAVE THE TARGET ORGANISM AS THE ASSAY ORGANISM?
+                data = data.filter(assay__organism__isnull=False) | data.filter(assay__target__organism__isnull=False)
                 # Exclude where organism is "Unspecified"
-                data = data.exclude(assay__organism="Unspecified").exclude(target__organism="Unspecified")
+                data = data.exclude(assay__organism="Unspecified").exclude(assay__target__organism="Unspecified")
 
             length = data.count()
 

--- a/cellsamples/models.py
+++ b/cellsamples/models.py
@@ -118,7 +118,7 @@ class CellSample(RestrictedModel):
         ('F', 'Female'),
         ('M', 'Male'),
     )
-    patient_age = models.IntegerField(default='')
+    patient_age = models.IntegerField(blank=True, null=True)
     patient_gender = models.CharField(max_length=1, choices=GENDER_CHOICES,
                                       default=GENDER_CHOICES[0][0],
                                       blank=True)

--- a/cellsamples/models.py
+++ b/cellsamples/models.py
@@ -31,8 +31,7 @@ class CellType(LockableModel):
     cell_type = models.CharField(max_length=255,
                                  help_text='Example: hepatocyte, muscle, kidney, etc')
     species = models.CharField(max_length=10,
-                               choices=SPECIESTYPE, default='Human', null=True,
-                               blank=True)
+                               choices=SPECIESTYPE, default='Human')
 
     cell_subtype = models.ForeignKey('CellSubtype')
     organ = models.ForeignKey('Organ')
@@ -102,8 +101,7 @@ class CellSample(RestrictedModel):
         ('Other', 'Other'),
     )
     cell_source = models.CharField(max_length=20,
-                                   choices=CELLSOURCETYPE, default='Primary',
-                                   null=True, blank=True)
+                                   choices=CELLSOURCETYPE, default='Primary')
     notes = models.TextField(blank=True)
     receipt_date = models.DateField()
 
@@ -120,7 +118,7 @@ class CellSample(RestrictedModel):
         ('F', 'Female'),
         ('M', 'Male'),
     )
-    patient_age = models.IntegerField(null=True, blank=True)
+    patient_age = models.IntegerField(default='')
     patient_gender = models.CharField(max_length=1, choices=GENDER_CHOICES,
                                       default=GENDER_CHOICES[0][0],
                                       blank=True)

--- a/cellsamples/models.py
+++ b/cellsamples/models.py
@@ -31,7 +31,8 @@ class CellType(LockableModel):
     cell_type = models.CharField(max_length=255,
                                  help_text='Example: hepatocyte, muscle, kidney, etc')
     species = models.CharField(max_length=10,
-                               choices=SPECIESTYPE, default='Human')
+                               choices=SPECIESTYPE, default='Human', null=True,
+                               blank=True)
 
     cell_subtype = models.ForeignKey('CellSubtype')
     organ = models.ForeignKey('Organ')
@@ -101,7 +102,8 @@ class CellSample(RestrictedModel):
         ('Other', 'Other'),
     )
     cell_source = models.CharField(max_length=20,
-                                   choices=CELLSOURCETYPE, default='Primary')
+                                   choices=CELLSOURCETYPE, default='Primary',
+                                   null=True, blank=True)
     notes = models.TextField(blank=True)
     receipt_date = models.DateField()
 
@@ -118,7 +120,7 @@ class CellSample(RestrictedModel):
         ('F', 'Female'),
         ('M', 'Male'),
     )
-    patient_age = models.IntegerField(blank=True, null=True)
+    patient_age = models.IntegerField(null=True, blank=True)
     patient_gender = models.CharField(max_length=1, choices=GENDER_CHOICES,
                                       default=GENDER_CHOICES[0][0],
                                       blank=True)

--- a/compounds/admin.py
+++ b/compounds/admin.py
@@ -22,7 +22,7 @@ class CompoundSummaryInline(admin.TabularInline):
 
     fields = (
         (
-            ('compound','summary_type','summary',)
+            ('compound','summary_type','summary','source')
         ),
     )
     extra = 0
@@ -40,7 +40,7 @@ class CompoundPropertyInline(admin.TabularInline):
 
     fields = (
         (
-            ('compound','property_type','value',)
+            ('compound','property_type','value','source')
         ),
     )
     extra = 0

--- a/compounds/admin.py
+++ b/compounds/admin.py
@@ -9,7 +9,44 @@ from bioservices import ChEMBL as ChEMBLdb
 
 from compounds.resource import CompoundResource
 from mps.base.admin import LockableAdmin
-from compounds.models import Compound
+from compounds.models import *
+from compounds.forms import *
+
+
+class CompoundSummaryInline(admin.TabularInline):
+    # Assays for ChipReadout
+    formset = CompoundSummaryInlineFormset
+    model = CompoundSummary
+    verbose_name = 'Compound Summary'
+    verbose_plural_name = 'Compound Summaries'
+
+    fields = (
+        (
+            ('compound','summary_type','summary',)
+        ),
+    )
+    extra = 0
+
+    # class Media(object):
+    #     css = {"all": ("css/hide_admin_original.css",)}
+
+
+class CompoundPropertyInline(admin.TabularInline):
+    # Assays for ChipReadout
+    formset = CompoundPropertyInlineFormset
+    model = CompoundProperty
+    verbose_name = 'Compound Properties'
+    verbose_plural_name = 'Compound Properties'
+
+    fields = (
+        (
+            ('compound','property','value',)
+        ),
+    )
+    extra = 0
+
+    # class Media(object):
+    #     css = {"all": ("css/hide_admin_original.css",)}
 
 
 class CompoundAdmin(LockableAdmin):
@@ -24,6 +61,8 @@ class CompoundAdmin(LockableAdmin):
                                     widget=forms.Textarea(),
                                     help_text="<br>ChEMBL IDs separated by a "
                                               "space or a new line.")
+
+    inlines = [CompoundSummaryInline, CompoundPropertyInline]
 
     save_on_top = True
     list_per_page = 300
@@ -149,3 +188,79 @@ class CompoundAdmin(LockableAdmin):
 
 
 admin.site.register(Compound, CompoundAdmin)
+
+
+class SummaryTypeAdmin(LockableAdmin):
+    save_on_top = True
+
+    search_fields = ['name', 'description',]
+    list_filter = ['name',]
+
+    list_display = (
+        'name',
+        'description'
+    )
+
+    readonly_fields = ('created_by', 'created_on',
+                       'modified_by', 'modified_on',)
+
+    fieldsets = (
+       (
+           "Summary Type Data", {
+               'fields': (
+                   'name',
+                   'description',
+               )
+           }
+       ),
+       ('Change Tracking', {
+           'fields': (
+               'locked',
+               ('created_by', 'created_on'),
+               ('modified_by', 'modified_on'),
+               ('signed_off_by', 'signed_off_date'),
+           )
+       }
+       ),
+    )
+
+
+admin.site.register(SummaryType, SummaryTypeAdmin)
+
+
+class PropertyTypeAdmin(LockableAdmin):
+    save_on_top = True
+
+    search_fields = ['name', 'description',]
+    list_filter = ['name',]
+
+    list_display = (
+        'name',
+        'description'
+    )
+
+    readonly_fields = ('created_by', 'created_on',
+                       'modified_by', 'modified_on',)
+
+    fieldsets = (
+       (
+           "Property Data", {
+               'fields': (
+                   'name',
+                   'description',
+               )
+           }
+       ),
+       ('Change Tracking', {
+           'fields': (
+               'locked',
+               ('created_by', 'created_on'),
+               ('modified_by', 'modified_on'),
+               ('signed_off_by', 'signed_off_date'),
+           )
+       }
+       ),
+    )
+
+
+admin.site.register(PropertyType, PropertyTypeAdmin)

--- a/compounds/admin.py
+++ b/compounds/admin.py
@@ -40,7 +40,7 @@ class CompoundPropertyInline(admin.TabularInline):
 
     fields = (
         (
-            ('compound','property','value',)
+            ('compound','property_type','value',)
         ),
     )
     extra = 0

--- a/compounds/ajax.py
+++ b/compounds/ajax.py
@@ -119,7 +119,8 @@ def fetch_compound_report(request):
             data.get(compound.name).get('table').update({property_type:properties.get(compound.name+property_type,'')})
 
     # Acquire AssayChipRawData and store based on compound-assay (and convert to minutes?)
-    readouts = AssayChipRawData.objects.filter(assay_chip_id__chip_setup__compound__in=compounds).select_related('assay_chip_id__chip_setup__compound', 'assay_chip_id.chip_setup.unit')
+    readouts = AssayChipRawData.objects.filter(assay_chip_id__chip_setup__compound__in=compounds,
+                                               assay_id__readout_unit__unit='%Control').select_related('assay_chip_id__chip_setup__compound', 'assay_chip_id.chip_setup.unit')
 
     for readout in readouts:
         compound = readout.assay_chip_id.chip_setup.compound.name

--- a/compounds/ajax.py
+++ b/compounds/ajax.py
@@ -84,6 +84,8 @@ def fetch_compound_report(request):
     summary_types = (
         'Pre-clinical Findings',
         'Clinical Findings',
+        # Recently added
+        'PK/Metabolism',
     )
     property_types = (
         'Dose (xCmax)',

--- a/compounds/ajax.py
+++ b/compounds/ajax.py
@@ -147,7 +147,8 @@ def fetch_compound_report(request):
                 for time in entry:
                     entry.update({time:float(sum(entry.get(time)))/len(entry.get(time))})
                 # Add maximum
-                data[compound]['table']['max_time'].update({assay+'_'+concentration: max(entry.keys())})
+                if assay not in data[compound]['table']['max_time'] or max(entry.keys()) > data[compound]['table']['max_time'][assay]:
+                    data[compound]['table']['max_time'].update({assay: max(entry.keys())})
 
     return HttpResponse(json.dumps(data),
                         content_type="application/json")

--- a/compounds/ajax.py
+++ b/compounds/ajax.py
@@ -22,7 +22,6 @@ def main(request):
     return render_to_response('ajax_error.html',
                               context_instance=RequestContext(request))
 
-
 def fetch_compound_name(request):
     data = {}
 
@@ -32,14 +31,12 @@ def fetch_compound_name(request):
     return HttpResponse(json.dumps(data),
                         content_type="application/json")
 
-
 def chembl_error(error):
     data = {}
     data.update({'error': error})
 
     return HttpResponse(json.dumps(data),
                         content_type="application/json")
-
 
 def fetch_chemblid_data(request):
     chemblid = request.POST['chemblid']
@@ -179,4 +176,3 @@ def ajax(request):
     else:
         # execute the function
         return procedure(request)
-

--- a/compounds/forms.py
+++ b/compounds/forms.py
@@ -1,5 +1,7 @@
 from django import forms
-from .models import Compound
+from .models import *
+from django.forms.models import BaseInlineFormSet
+
 
 class CompoundForm(forms.ModelForm):
 
@@ -31,3 +33,16 @@ class CompoundForm(forms.ModelForm):
             raise forms.ValidationError('A compound with the given PubChem ID already exists')
 
         return self.cleaned_data
+
+
+class CompoundSummaryInlineFormset(BaseInlineFormSet):
+    class Meta(object):
+        model = CompoundSummary
+        exclude = ('',)
+
+
+class CompoundPropertyInlineFormset(BaseInlineFormSet):
+    class Meta(object):
+        model = CompoundProperty
+        exclude = ('',)
+

--- a/compounds/models.py
+++ b/compounds/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from mps.base.models import LockableModel
+from mps.base.models import LockableModel, FlaggableModel
 
 
 CHEMBL = None
@@ -185,3 +185,56 @@ class Compound(LockableModel):
 
     def get_absolute_url(self):
         return "/compounds/"
+
+
+class SummaryType(LockableModel):
+
+    class Meta(object):
+        verbose_name = 'Summary Type'
+        verbose_name_plural = 'Summary Types'
+
+    name = models.CharField(max_length=100)
+    description = models.CharField(max_length=500, default='')
+
+    def __unicode__(self):
+        return unicode(self.name)
+
+class PropertyType(LockableModel):
+
+    class Meta(object):
+        verbose_name = 'Compound Property Type'
+
+    name = models.CharField(max_length=100)
+    description = models.CharField(max_length=500, default='')
+
+    def __unicode__(self):
+        return unicode(self.name)
+
+
+# TODO CREATE TWO INLINES: ONE FOR SUMMARIES AND ONE FOR PROPERTIES
+# At worst, I suppose I can merge these together or even add them as fields in Compound
+# It would be useful to have a model that catalogues COMPOUND SUMMARIES such as non-clinical/clinical toxicology
+class CompoundSummary(models.Model):
+
+    class Meta(object):
+        unique_together = [('compound','summary_type')]
+        verbose_name = 'Compound Summary'
+        verbose_name_plural = 'Compound Summaries'
+
+    compound = models.ForeignKey(Compound)
+    summary_type = models.ForeignKey(SummaryType)
+    summary = models.CharField(max_length=500)
+
+
+# It would be useful to have a model that catalogues COMPOUND PROPERTIES such as cmax and clogp
+class CompoundProperty(models.Model):
+
+    class Meta(object):
+        unique_together = [('compound','property')]
+        verbose_name = 'Compound Property'
+        verbose_name_plural = 'Compound Properties'
+
+    compound = models.ForeignKey(Compound)
+    property = models.ForeignKey(PropertyType)
+    # After some amount of debate, it was decided a float field should be sufficient for out purposes
+    value = models.FloatField()

--- a/compounds/models.py
+++ b/compounds/models.py
@@ -50,15 +50,12 @@ class Compound(LockableModel):
     # The name, rather than the chemblid and/or inchikey, is unique
     name = models.CharField(max_length=200, unique=True,
         help_text="Preferred compound name.")
-    synonyms = models.TextField(max_length=4000,
-        null=True, blank=True)
-    tags = models.TextField(blank=True, null=True,
-        help_text="Tags for the compound (EPA, NCATS, etc.)")
+    synonyms = models.TextField(max_length=4000, default='')
+    tags = models.TextField(default='', help_text="Tags for the compound (EPA, NCATS, etc.)")
 
     # External identifiers are checked for uniqueness in form's clean
     # Not optimal, but other solutions did not seem to work (editing save, so on)
-    chemblid = models.CharField('ChEMBL ID', max_length=20,
-        null=True, blank=True,
+    chemblid = models.CharField('ChEMBL ID', max_length=20, default='',
         help_text="Enter a ChEMBL id, e.g. CHEMBL25, and click Retrieve to "
                   "get compound information automatically.")
 
@@ -67,15 +64,15 @@ class Compound(LockableModel):
 
     # standard names/identifiers
     inchikey = models.CharField('InChI key', max_length=27,
-        null=True, blank=True,
+        default='',
         help_text="IUPAC standard InChI key for the compound")
     smiles = models.CharField(max_length=1000,
-        null=True, blank=True,
+        default='',
         help_text="Canonical smiles, generated using pipeline pilot.")
 
     # molecular properties
     molecular_formula = models.CharField(max_length=40,
-        null=True, blank=True,
+        default='',
         help_text="Molecular formula of compound.")
     molecular_weight = models.FloatField(
         null=True, blank=True,
@@ -118,7 +115,7 @@ class Compound(LockableModel):
                   "that compounds that pass all these criteria are"
                   "more likely to be hits in fragment screening.")
     species = models.CharField('Molecular species', max_length=10,
-        blank=True, null=True,
+        default='',
         help_text="A description of the predominant species occurring at pH "
                   "7.4 and can be acid, base, neutral or zwitterion.")
 

--- a/compounds/models.py
+++ b/compounds/models.py
@@ -224,6 +224,7 @@ class CompoundSummary(models.Model):
     compound = models.ForeignKey(Compound)
     summary_type = models.ForeignKey(SummaryType)
     summary = models.CharField(max_length=500)
+    source = models.CharField(max_length=250)
 
     def __unicode__(self):
         return unicode(self.summary)
@@ -240,6 +241,7 @@ class CompoundProperty(models.Model):
     property_type = models.ForeignKey(PropertyType)
     # After some amount of debate, it was decided a float field should be sufficient for out purposes
     value = models.FloatField()
+    source = models.CharField(max_length=250)
 
     def __unicode__(self):
         return unicode(self.value)

--- a/compounds/models.py
+++ b/compounds/models.py
@@ -50,12 +50,15 @@ class Compound(LockableModel):
     # The name, rather than the chemblid and/or inchikey, is unique
     name = models.CharField(max_length=200, unique=True,
         help_text="Preferred compound name.")
-    synonyms = models.TextField(max_length=4000, default='')
-    tags = models.TextField(default='', help_text="Tags for the compound (EPA, NCATS, etc.)")
+    synonyms = models.TextField(max_length=4000,
+        null=True, blank=True)
+    tags = models.TextField(blank=True, null=True,
+        help_text="Tags for the compound (EPA, NCATS, etc.)")
 
     # External identifiers are checked for uniqueness in form's clean
     # Not optimal, but other solutions did not seem to work (editing save, so on)
-    chemblid = models.CharField('ChEMBL ID', max_length=20, default='',
+    chemblid = models.CharField('ChEMBL ID', max_length=20,
+        null=True, blank=True,
         help_text="Enter a ChEMBL id, e.g. CHEMBL25, and click Retrieve to "
                   "get compound information automatically.")
 
@@ -64,15 +67,15 @@ class Compound(LockableModel):
 
     # standard names/identifiers
     inchikey = models.CharField('InChI key', max_length=27,
-        default='',
+        null=True, blank=True,
         help_text="IUPAC standard InChI key for the compound")
     smiles = models.CharField(max_length=1000,
-        default='',
+        null=True, blank=True,
         help_text="Canonical smiles, generated using pipeline pilot.")
 
     # molecular properties
     molecular_formula = models.CharField(max_length=40,
-        default='',
+        null=True, blank=True,
         help_text="Molecular formula of compound.")
     molecular_weight = models.FloatField(
         null=True, blank=True,
@@ -115,7 +118,7 @@ class Compound(LockableModel):
                   "that compounds that pass all these criteria are"
                   "more likely to be hits in fragment screening.")
     species = models.CharField('Molecular species', max_length=10,
-        default='',
+        blank=True, null=True,
         help_text="A description of the predominant species occurring at pH "
                   "7.4 and can be acid, base, neutral or zwitterion.")
 

--- a/compounds/models.py
+++ b/compounds/models.py
@@ -225,16 +225,21 @@ class CompoundSummary(models.Model):
     summary_type = models.ForeignKey(SummaryType)
     summary = models.CharField(max_length=500)
 
+    def __unicode__(self):
+        return unicode(self.summary)
 
 # It would be useful to have a model that catalogues COMPOUND PROPERTIES such as cmax and clogp
 class CompoundProperty(models.Model):
 
     class Meta(object):
-        unique_together = [('compound','property')]
+        unique_together = [('compound','property_type')]
         verbose_name = 'Compound Property'
         verbose_name_plural = 'Compound Properties'
 
     compound = models.ForeignKey(Compound)
-    property = models.ForeignKey(PropertyType)
+    property_type = models.ForeignKey(PropertyType)
     # After some amount of debate, it was decided a float field should be sufficient for out purposes
     value = models.FloatField()
+
+    def __unicode__(self):
+        return unicode(self.value)

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -1,0 +1,112 @@
+// The compound report must be able to:
+// 1.) Employ some method to filter desired compounds (will resemble list display with checkboxes)
+// 2.) Display all of the requested compound data in the desired table
+// 3.) Display D3 "Sparklines" for every assay for the given compound (TODO LOOK AT D3 TECHNIQUE)
+
+$(document).ready(function () {
+    // Middleware token for CSRF validation
+    var middleware_token = getCookie('csrftoken');
+
+    // Object of all selected compounds
+    var compounds = {};
+
+    // AJAX call for getting data
+    function get_data() {
+        $.ajax({
+            url: "/compounds_ajax",
+            type: "POST",
+            dataType: "json",
+            data: {
+                call: 'fetch_compound_report',
+                compounds: JSON.stringify(compounds),
+                csrfmiddlewaretoken: middleware_token
+            },
+            success: function (json) {
+                // Stop spinner
+                window.spinner.stop();
+                // Build table
+                build_table(json);
+            },
+            error: function (xhr, errmsg, err) {
+                // Stop spinner
+                window.spinner.stop();
+                console.log(xhr.status + ": " + xhr.responseText);
+            }
+        });
+    }
+
+    function build_table(data) {
+        // Show graphic
+        $('#results_table').prop('hidden',false);
+
+        // Clear old (if present)
+        $('#results_table').dataTable().fnDestroy();
+        $('#results_body').html('');
+
+        for (var compound in data) {
+            var values = data[compound].table;
+            var row = "<tr>";
+            row += "<td><a href='/compounds/"+values['id']+"'>" + compound + "</a></td>";
+
+            row += "<td>" + values['Dose (xCmax)'] + "</td>";
+            row += "<td>" + values['cLogP']  + "</td>";
+            row += "<td>" + values['Pre-clinical Findings'] + "</td>";
+            row += "<td>" + values['Clinical Findings'] + "</td>";
+            row += "<td>" + values['id'] + "</td>";
+            row += "<td>" + values['id'] + "</td>";
+
+            row += "</tr>";
+            $('#results_body').append(row);
+        }
+
+        $('#results_table').DataTable({
+            dom: 'T<"clear">frtip',
+            "iDisplayLength": 100,
+            // Needed to destroy old table
+            "bDestroy": true
+        });
+
+        // Swap positions of filter and length selection
+        $('.dataTables_filter').css('float','left');
+        // Reposition download/print/copy
+        $('.DTTT_container').css('float', 'none');
+    }
+
+    // Submission
+    function submit() {
+        // Hide Selection html
+        $('#selection').prop('hidden',true);
+        // Show spinner
+        window.spinner.spin(
+            document.getElementById("spinner")
+        );
+        get_data();
+    }
+
+    // Checks whether the submission button was clicked
+    $('#submit').click(function() {
+        submit();
+    });
+
+    // Tracks the clicking of checkboxes to fill compounds
+    $('.checkbox').change( function() {
+        var compound = this.value;
+        if (this.checked) {
+            compounds[compound] = compound;
+        }
+        else {
+            delete compounds[compound]
+        }
+    });
+
+    window.onhashchange = function() {
+        if (location.hash != '#show') {
+            $('#graphic').prop('hidden', true);
+            $('#selection').prop('hidden', false);
+        }
+        else {
+            $('#graphic').prop('hidden', false);
+            $('#selection').prop('hidden', true);
+        }
+    };
+});

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
     // Object of all selected compounds
     var compounds = {};
 
-    var width = 100;
+    var width = 75;
     var height = 25;
     var x = d3.scale.linear().range([0, width]);
     var y = d3.scale.linear().range([height, 0]);

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -121,7 +121,7 @@ $(document).ready(function () {
             row += "<td>";
 
             // Make the table
-            row += "<table id='"+compound+"_table'>";
+            row += "<table id='"+compound+"_table' class='table table-striped table-bordered'>";
 
             // Add a row for the header
             row += "<tr id='"+compound+"_header'><td></td></tr>";
@@ -136,7 +136,7 @@ $(document).ready(function () {
                 // Tack this assay on to the header
                 $('#'+compound+'_header').append($('<td>')
                     // The use of days here is contrived, actual units to be decided on later
-                    .text(assay + ' (' + x_max[assay] + ' days)')
+                    .text(assay + ' (' + values.max_time[assay] + ' days)')
                     .addClass('small'));
                 for (var concentration in plot[assay]) {
                     var row_id = compound + '_' + concentration.replace('.','_');
@@ -148,9 +148,13 @@ $(document).ready(function () {
                             .append($('<td>')
                                 .text(concentration.replace('_',' '))));
                     }
-                    // Add a cell for the assay given concentration
-                    $('#'+row_id).append($('<td>')
-                        .attr('id', compound + '_' + assay + '_' + concentration.replace('.','_')));
+                    for (var every_assay in x_max) {
+                        // Add a cell for the assay given concentration
+                        if (!$('#'+compound + '_' + every_assay + '_' + concentration.replace('.','_'))[0]) {
+                            $('#' + row_id).append($('<td>')
+                                .attr('id', compound + '_' + every_assay + '_' + concentration.replace('.', '_')));
+                        }
+                    }
                 }
             }
 

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -136,8 +136,8 @@ $(document).ready(function () {
                 // Tack this assay on to the header
                 $('#'+compound+'_header').append($('<td>')
                     // The use of days here is contrived, actual units to be decided on later
-                    .text(assay + ' (' + values.max_time[assay] + ' days)')
-                    .addClass('small'));
+                    .addClass('small')
+                    .append('<span>'+assay+'<br>'+'(' + values.max_time[assay] + ' days)'+'</span>'));
                 for (var concentration in plot[assay]) {
                     var row_id = compound + '_' + concentration.replace('.','_');
                     // If the concentration does not have a row, add it to the table

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -30,8 +30,6 @@ $(document).ready(function () {
         // Sort by time
         data = _.sortBy(data, function(obj){ return +obj.time });
 
-        console.log(elem_id);
-
         x.domain(d3.extent(data, function(d) { return d.time; }));
         y.domain(d3.extent(data, function(d) { return d.value; }));
 

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -10,6 +10,41 @@ $(document).ready(function () {
     // Object of all selected compounds
     var compounds = {};
 
+    var width = 100;
+    var height = 25;
+    var x = d3.scale.linear().range([0, width]);
+    var y = d3.scale.linear().range([height, 0]);
+    var line = d3.svg.line()
+             .interpolate("basis")
+             .x(function(d) { return x(d.time); })
+             .y(function(d) { return y(d.value); });
+
+    function sparkline(elem_id, plot) {
+        data = [];
+        for (var time in plot) {
+            var value = +plot[time];
+            var x_time = +time;
+            data.push({'time':x_time, 'value':value});
+        }
+
+        // Sort by time
+        data = _.sortBy(data, function(obj){ return +obj.time });
+
+        console.log(elem_id);
+
+        x.domain(d3.extent(data, function(d) { return d.time; }));
+        y.domain(d3.extent(data, function(d) { return d.value; }));
+
+        d3.select(elem_id)
+            .append('svg')
+            .attr('width', width)
+            .attr('height', height)
+            .append('path')
+            .datum(data)
+            .attr('class', 'sparkline')
+            .attr('d', line);
+    }
+
     // AJAX call for getting data
     function get_data() {
         $.ajax({
@@ -45,25 +80,44 @@ $(document).ready(function () {
 
         for (var compound in data) {
             var values = data[compound].table;
-            var row = "<tr>";
-            row += "<td><a href='/compounds/"+values['id']+"'>" + compound + "</a></td>";
+            var plot = data[compound].plot;
 
+            var row = "<tr>";
+
+            row += "<td><a href='/compounds/"+values['id']+"'>" + compound + "</a></td>";
             row += "<td>" + values['Dose (xCmax)'] + "</td>";
             row += "<td>" + values['cLogP']  + "</td>";
             row += "<td>" + values['Pre-clinical Findings'] + "</td>";
             row += "<td>" + values['Clinical Findings'] + "</td>";
-            row += "<td>" + values['id'] + "</td>";
-            row += "<td>" + values['id'] + "</td>";
+
+            row += "<td>" + 'TODO' + "</td>";
+
+            row += "<td>";
+            for (var assay in plot) {
+                row += '<div>' + assay + '<span id='+compound+'_'+assay+'></span></div>';
+            }
+            row += "</td>";
 
             row += "</tr>";
             $('#results_body').append(row);
+
+            for (var assay in plot) {
+                sparkline('#'+compound+'_'+assay, plot[assay]);
+            }
         }
 
         $('#results_table').DataTable({
             dom: 'T<"clear">frtip',
             "iDisplayLength": 100,
             // Needed to destroy old table
-            "bDestroy": true
+            "bDestroy": true,
+            "order": [[ 0, "asc" ]],
+            "aoColumnDefs": [
+                {
+                    "bSortable": false,
+                    "aTargets": [6]
+                }
+            ]
         });
 
         // Swap positions of filter and length selection

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -87,8 +87,10 @@ $(document).ready(function () {
         for (var compound in data) {
             var all_plots = data[compound].plot;
             for (var assay in all_plots) {
-                x_max[assay] = 0;
-                y_max[assay] = 100;
+                if (!x_max[assay]) {
+                    x_max[assay] = 0;
+                    y_max[assay] = 100;
+                }
                 var assay_plots = all_plots[assay];
                 for (var concentration in assay_plots) {
                     for (var time in assay_plots[concentration]) {
@@ -109,25 +111,48 @@ $(document).ready(function () {
 
             row += "<td><a href='/compounds/"+values['id']+"'>" + compound + "</a></td>";
             row += "<td>" + values['Dose (xCmax)'] + "</td>";
-//            row += "<td>" + values['cLogP']  + "</td>";
+            row += "<td>" + values['cLogP']  + "</td>";
             row += "<td>" + values['Pre-clinical Findings'] + "</td>";
             row += "<td>" + values['Clinical Findings'] + "</td>";
 
-//            row += "<td>" + 'TODO' + "</td>";
+            // Recently added
+            row += "<td>" + values['PK/Metabolism'] + "</td>";
 
             row += "<td>";
-            for (var assay in plot) {
-                for (var concentration in plot[assay]) {
-                    // The use of days here is contrived, actual units to be decided on later
-                    row += '<div class="small">' + assay + ' (' + values.max_time[assay + '_' + concentration] + ' ' + 'days @ '
-                        + concentration + ')<span id=' + compound + '_'
-                        + assay + '_' + concentration.replace('.','_') + '></span></div>';
-                }
-            }
+
+            // Make the table
+            row += "<table id='"+compound+"_table'>";
+
+            // Add a row for the header
+            row += "<tr id='"+compound+"_header'><td></td></tr>";
+
+            row += "</table>";
             row += "</td>";
 
             row += "</tr>";
             $('#results_body').append(row);
+
+            for (var assay in plot) {
+                // Tack this assay on to the header
+                $('#'+compound+'_header').append($('<td>')
+                    // The use of days here is contrived, actual units to be decided on later
+                    .text(assay + ' (' + x_max[assay] + ' days)')
+                    .addClass('small'));
+                for (var concentration in plot[assay]) {
+                    var row_id = compound + '_' + concentration.replace('.','_');
+                    // If the concentration does not have a row, add it to the table
+                    if (!$('#'+row_id)[0]) {
+                        // Add the row
+                        $('#'+compound+'_table').append($('<tr>')
+                            .attr('id', row_id)
+                            .append($('<td>')
+                                .text(concentration.replace('_',' '))));
+                    }
+                    // Add a cell for the assay given concentration
+                    $('#'+row_id).append($('<td>')
+                        .attr('id', compound + '_' + assay + '_' + concentration.replace('.','_')));
+                }
+            }
 
             for (var assay in plot) {
                 for (var concentration in plot[assay]) {
@@ -150,7 +175,7 @@ $(document).ready(function () {
             "aoColumnDefs": [
                 {
                     "bSortable": false,
-                    "aTargets": [4]
+                    "aTargets": [6]
                 }
             ]
         });

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
     // Object of all selected compounds
     var compounds = {};
 
-    var width = 75;
+    var width = 50;
     var height = 25;
     var x = d3.scale.linear().range([0, width]);
     var y = d3.scale.linear().range([height, 0]);

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -92,7 +92,12 @@ $(document).ready(function () {
 
             row += "<td>";
             for (var assay in plot) {
-                row += '<div>' + assay + '<span id='+compound+'_'+assay+'></span></div>';
+                for (var concentration in plot[assay]) {
+                    // The use of days here is contrived, actual units to be decided on later
+                    row += '<div class="small">' + assay + ' (' + values.max_time[assay + '_' + concentration] + ' ' + 'days @ '
+                        + concentration + ')<span id=' + compound + '_'
+                        + assay + '_' + concentration.replace('.','_') + '></span></div>';
+                }
             }
             row += "</td>";
 
@@ -100,12 +105,14 @@ $(document).ready(function () {
             $('#results_body').append(row);
 
             for (var assay in plot) {
-                sparkline('#'+compound+'_'+assay, plot[assay]);
+                for (var concentration in plot[assay]) {
+                    sparkline('#' + compound + '_' + assay + '_' + concentration.replace('.','_'), plot[assay][concentration]);
+                }
             }
         }
 
         $('#results_table').DataTable({
-            dom: 'T<"clear">frtip',
+            dom: 'T<"clear">rt',
             "iDisplayLength": 100,
             // Needed to destroy old table
             "bDestroy": true,

--- a/compounds/static/compounds/compound_report.js
+++ b/compounds/static/compounds/compound_report.js
@@ -70,7 +70,7 @@ $(document).ready(function () {
 
     function build_table(data) {
         // Show graphic
-        $('#results_table').prop('hidden',false);
+        $('#graphic').prop('hidden',false);
 
         // Clear old (if present)
         $('#results_table').dataTable().fnDestroy();

--- a/compounds/static/compounds/compound_update.js
+++ b/compounds/static/compounds/compound_update.js
@@ -8,7 +8,7 @@ $(document).ready(function () {
 
     var inlines_property = $('#compoundproperty_set-group .inline');
     var next_id_property = inlines_property.length;
-    var title_property = $('.inline')[0].id.split('-')[0];
+    var title_property = 'property';
     var add_property = $('#compoundproperty_set-group .inline:last').html();
 
     $('#add_button_property').click(function() {
@@ -77,7 +77,7 @@ $(document).ready(function () {
 
     var inlines_summary = $('#compoundsummary_set-group .inline');
     var next_id_summary = inlines_summary.length;
-    var title_summary = $('.inline')[0].id.split('-')[0];
+    var title_summary = 'summary';
     var add_summary = $('#compoundsummary_set-group .inline:last').html();
 
     $('#add_button_summary').click(function() {
@@ -125,8 +125,8 @@ $(document).ready(function () {
 
             // Need to update values before creating the replacement text
             // Add values to input
-            $('#'+ title_summary +'-'+ i + ' input').each(function () {
-                $(this).attr("value", this.value);
+            $('#'+ title_summary +'-'+ i + ' textarea').each(function () {
+                $(this).text(this.text());
             });
             // Add selected attribute to selected option of each select
             $('#'+ title_summary +'-'+ i + ' select').each(function (){

--- a/compounds/static/compounds/compound_update.js
+++ b/compounds/static/compounds/compound_update.js
@@ -1,0 +1,146 @@
+// TODO This file really should not exist
+// TODO This was made in the interest of time, but it makes more sense to modify inline_add to be general
+// Perhaps there will not be any more models with multiple inlines, but perhaps not so it is something I should look in to
+$(document).ready(function () {
+
+    // Note that this requires certain class name, add name, inlines name
+    // Note that the selector that selects TABLES (not divs) with the name inlines
+
+    var inlines_property = $('#compoundproperty_set-group .inline');
+    var next_id_property = inlines_property.length;
+    var title_property = $('.inline')[0].id.split('-')[0];
+    var add_property = $('#compoundproperty_set-group .inline:last').html();
+
+    $('#add_button_property').click(function() {
+        var tag = '<tr class="inline" id="' + title_property + '-' + next_id_property + '">';
+        // Use a regular expression to replace all the places where ID is needed
+        // In case the RegExp looks a little obfuscated, it means to replace any number of digits that fall between two hyphens
+        $(tag).appendTo($("table[name='inlines_property']")).html(add_property.replace(/\-\d+\-/g,'-'+ next_id_property +'-'));
+        next_id_property += 1;
+        // Set the hidden TOTAL_FORMS to be incremented, otherwise won't bother reading other inline
+        $("#id_compoundproperty_set-TOTAL_FORMS").val(""+next_id_property);
+    });
+
+    // This selector will check all items with DELETE in the name, including newly created ones
+    $("body").on( "click", "#compoundproperty_set-group input[name*='DELETE']", function(event) {
+        // Use a regex to get the desired ID number
+        // var thenum = thestring.match(/\d+$/)[0];
+        var id = parseInt(event.target.id.match(/\d+/)[0]);
+
+        // Prevent user from removing ALL inlines (can cause unexpected behavior)
+        if ($("#compoundproperty_set-group input[name*='DELETE']").length < 2) {
+            // Uncheck
+            $("input[name*='DELETE']").prop('checked', false);
+            return;
+        }
+
+        // Exit the function if this is an update page (if it has an original, it already exists)
+        if ($('#' + title_property + '-' + id + ' .original')[0]) {
+            return;
+        }
+
+        // Remove the element
+        $('#'+title_property+'-'+id).remove();
+
+        // Need to find way to correctly decrement TOTAL_FORMS and next_id to avoid conflict
+        // Rename all greater than deleted, next_id = inlines.length
+        inlines_property = $('#compoundproperty_set-group .inline');
+        next_id_property = inlines_property.length;
+
+        // Decrease TOTAL_FORMS
+        $("#id_compoundproperty_set-TOTAL_FORMS").val(""+inlines_property.length);
+
+        var end = inlines_property.length;
+        for (var i=id+1; i<=end; i++){
+            var current = $('#'+title_property+'-'+i);
+
+            // Need to update values before creating the replacement text
+            // Add values to input
+            $('#'+ title_property +'-'+ i + ' input').each(function () {
+                $(this).attr("value", this.value);
+            });
+            // Add selected attribute to selected option of each select
+            $('#'+ title_property +'-'+ i + ' select').each(function (){
+                //console.log(this.id);
+                $('#' + this.id + ' option[value="' + $(this).val() + '"]').attr("selected", true);
+            });
+
+            var replacement = current.html().replace(/\-\d+\-/g,'-'+ (i-1) +'-');
+            //console.log(replacement);
+            //console.log("Iter:" + i);
+            var tag = '<tr class="inline" id="' + title_property + '-' + (i-1) + '">';
+            $(tag).appendTo($("table[name='inlines_property']")).html(replacement);
+            // Remove old
+            current.remove();
+        }
+    });
+
+    var inlines_summary = $('#compoundsummary_set-group .inline');
+    var next_id_summary = inlines_summary.length;
+    var title_summary = $('.inline')[0].id.split('-')[0];
+    var add_summary = $('#compoundsummary_set-group .inline:last').html();
+
+    $('#add_button_summary').click(function() {
+        var tag = '<tr class="inline" id="' + title_summary + '-' + next_id_summary + '">';
+        // Use a regular expression to replace all the places where ID is needed
+        // In case the RegExp looks a little obfuscated, it means to replace any number of digits that fall between two hyphens
+        $(tag).appendTo($("table[name='inlines_summary']")).html(add_summary.replace(/\-\d+\-/g,'-'+ next_id_summary +'-'));
+        next_id_summary += 1;
+        // Set the hidden TOTAL_FORMS to be incremented, otherwise won't bother reading other inline
+        $("#id_compoundsummary_set-TOTAL_FORMS").val(""+next_id_summary);
+    });
+
+    // This selector will check all items with DELETE in the name, including newly created ones
+    $("body").on( "click", "#compoundsummary_set-group input[name*='DELETE']", function(event) {
+        // Use a regex to get the desired ID number
+        // var thenum = thestring.match(/\d+$/)[0];
+        var id = parseInt(event.target.id.match(/\d+/)[0]);
+
+        // Prevent user from removing ALL inlines (can cause unexpected behavior)
+        if ($("#compoundsummary_set-group input[name*='DELETE']").length < 2) {
+            // Uncheck
+            $("input[name*='DELETE']").prop('checked', false);
+            return;
+        }
+
+        // Exit the function if this is an update page (if it has an original, it already exists)
+        if ($('#' + title_summary + '-' + id + ' .original')[0]) {
+            return;
+        }
+
+        // Remove the element
+        $('#'+title_summary+'-'+id).remove();
+
+        // Need to find way to correctly decrement TOTAL_FORMS and next_id to avoid conflict
+        // Rename all greater than deleted, next_id = inlines.length
+        inlines_summary = $('#compoundsummary_set-group .inline');
+        next_id_summary = inlines_summary.length;
+
+        // Decrease TOTAL_FORMS
+        $("#id_compoundsummary_set-TOTAL_FORMS").val(""+inlines_summary.length);
+
+        var end = inlines_summary.length;
+        for (var i=id+1; i<=end; i++){
+            var current = $('#'+title_summary+'-'+i);
+
+            // Need to update values before creating the replacement text
+            // Add values to input
+            $('#'+ title_summary +'-'+ i + ' input').each(function () {
+                $(this).attr("value", this.value);
+            });
+            // Add selected attribute to selected option of each select
+            $('#'+ title_summary +'-'+ i + ' select').each(function (){
+                //console.log(this.id);
+                $('#' + this.id + ' option[value="' + $(this).val() + '"]').attr("selected", true);
+            });
+
+            var replacement = current.html().replace(/\-\d+\-/g,'-'+ (i-1) +'-');
+            //console.log(replacement);
+            //console.log("Iter:" + i);
+            var tag = '<tr class="inline" id="' + title_summary + '-' + (i-1) + '">';
+            $(tag).appendTo($("table[name='inlines_summary']")).html(replacement);
+            // Remove old
+            current.remove();
+        }
+    });
+});

--- a/compounds/urls.py
+++ b/compounds/urls.py
@@ -5,4 +5,5 @@ urlpatterns = patterns('',
     url(r'^compounds/$', CompoundsList.as_view(), name='compound-list'),
     url(r'^compounds/add/$', CompoundsAdd.as_view(), name='compound-add'),
     url(r'^compounds/(?P<pk>[0-9]+)/$', CompoundsDetail.as_view(), name='compound-detail'),
+    url(r'^compounds/(?P<pk>[0-9]+)/update/$', CompoundsUpdate.as_view(), name='compound-update'),
 )

--- a/compounds/urls.py
+++ b/compounds/urls.py
@@ -4,6 +4,7 @@ from .views import *
 urlpatterns = patterns('',
     url(r'^compounds/$', CompoundsList.as_view(), name='compound-list'),
     url(r'^compounds/add/$', CompoundsAdd.as_view(), name='compound-add'),
+    url(r'^compounds/report/$', CompoundsReport.as_view(), name='compound-report'),
     url(r'^compounds/(?P<pk>[0-9]+)/$', CompoundsDetail.as_view(), name='compound-detail'),
     url(r'^compounds/(?P<pk>[0-9]+)/update/$', CompoundsUpdate.as_view(), name='compound-update'),
 )

--- a/compounds/views.py
+++ b/compounds/views.py
@@ -92,7 +92,8 @@ class CompoundsUpdate(OneGroupRequiredMixin, UpdateView):
             self.get_context_data(formset_summary=formset_summary,
                                   formset_property=formset_property))
 
-# def compound_report(request):
-#     """This will give a table summary based on the specifications given"""
-#     c = RequestContext(request)
-#     return render_to_response('compounds/report.html', c)
+
+# Currently, compounds report basically begins as just a compounds list
+class CompoundsReport(ListView):
+    model = Compound
+    template_name = 'compounds/compounds_report.html'

--- a/drugtrials/models.py
+++ b/drugtrials/models.py
@@ -40,7 +40,7 @@ class TrialSource(LockableModel):
         ordering = ('source_name', )
     source_name = models.CharField(max_length=40, unique=True)
     source_website = models.URLField(blank=True, null=True)
-    description = models.CharField(max_length=400, default='')
+    description = models.CharField(max_length=400, blank=True, null=True)
 
     def __unicode__(self):
         return self.source_name
@@ -61,8 +61,8 @@ class DrugTrial(LockableModel):
         verbose_name = 'Drug Trial'
         ordering = ('compound', 'species', )
 
-    title = models.CharField(max_length=255, default='')
-    condition = models.CharField(max_length=1400, default='')
+    title = models.CharField(max_length=255, blank=True, null=True)
+    condition = models.CharField(max_length=1400, blank=True, null=True)
     source = models.ForeignKey(TrialSource)
     compound = models.ForeignKey('compounds.Compound')
 
@@ -83,10 +83,14 @@ class DrugTrial(LockableModel):
                                   ('X', 'mixed'),
                                   ('U', 'unknown or unspecified'),
                               ),
-                              default='U')
+                              default='U',
+                              blank=True,
+                              null=True)
 
     population_size = models.CharField(max_length=50,
-                                       default='1')
+                                       default='1',
+                                       blank=True,
+                                       null=True)
 
     age_average = models.FloatField(blank=True, null=True)
 
@@ -95,6 +99,8 @@ class DrugTrial(LockableModel):
     age_min = models.FloatField(blank=True, null=True)
 
     age_unit = models.CharField(max_length=1,
+                                blank=True,
+                                null=True,
                                 choices=(
                                     ('M', 'months'), ('Y', 'years')
                                 ),
@@ -103,7 +109,7 @@ class DrugTrial(LockableModel):
     weight_average = models.FloatField(blank=True, null=True)
     weight_max = models.FloatField(blank=True, null=True)
     weight_min = models.FloatField(blank=True, null=True)
-    weight_unit = models.CharField(max_length=1,
+    weight_unit = models.CharField(max_length=1, blank=True, null=True,
                                    choices=(
                                        ('K', 'kilograms'), ('L', 'pounds'),
                                    ),
@@ -148,9 +154,9 @@ class Test(LockableModel):
     test_type = models.ForeignKey(TestType)
     test_name = models.CharField(max_length=40,
                                  verbose_name='Organ Function Test')
-    test_unit = models.CharField(max_length=40, default='')
+    test_unit = models.CharField(max_length=40, blank=True, null=True)
     organ = models.ForeignKey(Organ, blank=True, null=True)
-    description = models.CharField(max_length=400, default='')
+    description = models.CharField(max_length=400, blank=True, null=True)
 
     def __unicode__(self):
         return u'{} :: {} :: {}'.format(self.organ,
@@ -164,7 +170,7 @@ class FindingType(LockableModel):
         ordering = ('finding_type', )
 
     finding_type = models.CharField(max_length=100, unique=True)
-    description = models.CharField(max_length=200, default='')
+    description = models.CharField(max_length=200, blank=True, null=True)
 
     def __unicode__(self):
         return self.finding_type
@@ -177,11 +183,11 @@ class Finding(LockableModel):
 
     finding_type = models.ForeignKey(FindingType)
     finding_name = models.CharField(max_length=100)
-    finding_unit = models.CharField(max_length=40, default='')
+    finding_unit = models.CharField(max_length=40, blank=True, null=True)
     organ = models.ForeignKey(Organ,
                               blank=True,
                               null=True)
-    description = models.CharField(max_length=400, default='')
+    description = models.CharField(max_length=400, blank=True, null=True)
 
     def __unicode__(self):
         return u'{} :: {} :: {}'.format(self.organ, self.finding_type, self.finding_name)
@@ -235,12 +241,16 @@ class TestResult(models.Model):
     result = models.CharField(default='1',
                               max_length=8,
                               choices=POSNEG,
-                              verbose_name='Pos/Neg?')
+                              verbose_name='Pos/Neg?',
+                              blank=True,
+                              null=True)
 
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity')
+                                verbose_name='Severity',
+                                blank=True,
+                                null=True)
 
     percent_min = models.FloatField(blank=True,
                                     null=True,
@@ -311,7 +321,9 @@ class FindingResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity')
+                                verbose_name='Severity',
+                                blank=True,
+                                null=True)
 
     # May drop percent_min later, hide for now
     percent_min = models.FloatField(blank=True,
@@ -325,7 +337,8 @@ class FindingResult(models.Model):
 
     frequency = models.CharField(choices=FREQUENCIES,
                                  max_length=25,
-                                 default='')
+                                 blank=True,
+                                 null=True,)
 
     descriptor = models.ForeignKey(ResultDescriptor, blank=True, null=True)
 
@@ -356,11 +369,11 @@ class OpenFDACompound(LockableModel):
         verbose_name = 'OpenFDA Report'
 
     compound = models.ForeignKey('compounds.Compound')
-    warnings = models.TextField(default='')
+    warnings = models.TextField(blank=True, null=True)
     black_box = models.BooleanField(default=False)
 
     # Insights into non-human toxicology (can be useful)
-    nonclinical_toxicology = models.TextField(default='')
+    nonclinical_toxicology = models.TextField(blank=True, null=True)
 
     # Deemed less than useful
     #clinical_studies = models.TextField(blank=True, null=True)

--- a/drugtrials/models.py
+++ b/drugtrials/models.py
@@ -40,7 +40,7 @@ class TrialSource(LockableModel):
         ordering = ('source_name', )
     source_name = models.CharField(max_length=40, unique=True)
     source_website = models.URLField(blank=True, null=True)
-    description = models.CharField(max_length=400, blank=True, null=True)
+    description = models.CharField(max_length=400, default='')
 
     def __unicode__(self):
         return self.source_name
@@ -61,8 +61,8 @@ class DrugTrial(LockableModel):
         verbose_name = 'Drug Trial'
         ordering = ('compound', 'species', )
 
-    title = models.CharField(max_length=255, blank=True, null=True)
-    condition = models.CharField(max_length=1400, blank=True, null=True)
+    title = models.CharField(max_length=255, default='')
+    condition = models.CharField(max_length=1400, default='')
     source = models.ForeignKey(TrialSource)
     compound = models.ForeignKey('compounds.Compound')
 
@@ -83,14 +83,10 @@ class DrugTrial(LockableModel):
                                   ('X', 'mixed'),
                                   ('U', 'unknown or unspecified'),
                               ),
-                              default='U',
-                              blank=True,
-                              null=True)
+                              default='U')
 
     population_size = models.CharField(max_length=50,
-                                       default='1',
-                                       blank=True,
-                                       null=True)
+                                       default='1')
 
     age_average = models.FloatField(blank=True, null=True)
 
@@ -99,8 +95,6 @@ class DrugTrial(LockableModel):
     age_min = models.FloatField(blank=True, null=True)
 
     age_unit = models.CharField(max_length=1,
-                                blank=True,
-                                null=True,
                                 choices=(
                                     ('M', 'months'), ('Y', 'years')
                                 ),
@@ -109,7 +103,7 @@ class DrugTrial(LockableModel):
     weight_average = models.FloatField(blank=True, null=True)
     weight_max = models.FloatField(blank=True, null=True)
     weight_min = models.FloatField(blank=True, null=True)
-    weight_unit = models.CharField(max_length=1, blank=True, null=True,
+    weight_unit = models.CharField(max_length=1,
                                    choices=(
                                        ('K', 'kilograms'), ('L', 'pounds'),
                                    ),
@@ -154,9 +148,9 @@ class Test(LockableModel):
     test_type = models.ForeignKey(TestType)
     test_name = models.CharField(max_length=40,
                                  verbose_name='Organ Function Test')
-    test_unit = models.CharField(max_length=40, blank=True, null=True)
+    test_unit = models.CharField(max_length=40, default='')
     organ = models.ForeignKey(Organ, blank=True, null=True)
-    description = models.CharField(max_length=400, blank=True, null=True)
+    description = models.CharField(max_length=400, default='')
 
     def __unicode__(self):
         return u'{} :: {} :: {}'.format(self.organ,
@@ -170,7 +164,7 @@ class FindingType(LockableModel):
         ordering = ('finding_type', )
 
     finding_type = models.CharField(max_length=100, unique=True)
-    description = models.CharField(max_length=200, blank=True, null=True)
+    description = models.CharField(max_length=200, default='')
 
     def __unicode__(self):
         return self.finding_type
@@ -183,11 +177,11 @@ class Finding(LockableModel):
 
     finding_type = models.ForeignKey(FindingType)
     finding_name = models.CharField(max_length=100)
-    finding_unit = models.CharField(max_length=40, blank=True, null=True)
+    finding_unit = models.CharField(max_length=40, default='')
     organ = models.ForeignKey(Organ,
                               blank=True,
                               null=True)
-    description = models.CharField(max_length=400, blank=True, null=True)
+    description = models.CharField(max_length=400, default='')
 
     def __unicode__(self):
         return u'{} :: {} :: {}'.format(self.organ, self.finding_type, self.finding_name)
@@ -241,16 +235,12 @@ class TestResult(models.Model):
     result = models.CharField(default='1',
                               max_length=8,
                               choices=POSNEG,
-                              verbose_name='Pos/Neg?',
-                              blank=True,
-                              null=True)
+                              verbose_name='Pos/Neg?')
 
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity',
-                                blank=True,
-                                null=True)
+                                verbose_name='Severity')
 
     percent_min = models.FloatField(blank=True,
                                     null=True,
@@ -321,9 +311,7 @@ class FindingResult(models.Model):
     severity = models.CharField(default='-1',
                                 max_length=5,
                                 choices=SEVERITY_SCORE,
-                                verbose_name='Severity',
-                                blank=True,
-                                null=True)
+                                verbose_name='Severity')
 
     # May drop percent_min later, hide for now
     percent_min = models.FloatField(blank=True,
@@ -337,8 +325,7 @@ class FindingResult(models.Model):
 
     frequency = models.CharField(choices=FREQUENCIES,
                                  max_length=25,
-                                 blank=True,
-                                 null=True,)
+                                 default='')
 
     descriptor = models.ForeignKey(ResultDescriptor, blank=True, null=True)
 
@@ -369,11 +356,11 @@ class OpenFDACompound(LockableModel):
         verbose_name = 'OpenFDA Report'
 
     compound = models.ForeignKey('compounds.Compound')
-    warnings = models.TextField(blank=True, null=True)
+    warnings = models.TextField(default='')
     black_box = models.BooleanField(default=False)
 
     # Insights into non-human toxicology (can be useful)
-    nonclinical_toxicology = models.TextField(blank=True, null=True)
+    nonclinical_toxicology = models.TextField(default='')
 
     # Deemed less than useful
     #clinical_studies = models.TextField(blank=True, null=True)

--- a/microdevices/models.py
+++ b/microdevices/models.py
@@ -11,8 +11,8 @@ class MicrophysiologyCenter(LockableModel):
 
     center_name = models.CharField(max_length=100)
     center_id = models.CharField(max_length=20,default='-')
-    description = models.CharField(max_length=400, blank=True, null=True)
-    contact_person = models.CharField(max_length=250, blank=True, null=True)
+    description = models.CharField(max_length=400, default='')
+    contact_person = models.CharField(max_length=250, default='')
     center_website = models.URLField(blank=True, null=True)
 
     groups = models.ManyToManyField(Group)
@@ -26,7 +26,7 @@ class Manufacturer(LockableModel):
         ordering = ('manufacturer_name', )
 
     manufacturer_name = models.CharField(max_length=100)
-    contact_person = models.CharField(max_length=250, blank=True, null=True)
+    contact_person = models.CharField(max_length=250, default='')
     Manufacturer_website = models.URLField(blank=True, null=True)
 
     def __unicode__(self):
@@ -43,9 +43,9 @@ class Microdevice(LockableModel):
     center = models.ForeignKey(MicrophysiologyCenter, blank=True, null=True)
     manufacturer = models.ForeignKey(Manufacturer, null=True, blank=True)
     barcode = models.CharField(
-        max_length=200, verbose_name='version/ catalog#', null=True, blank=True)
+        max_length=200, verbose_name='version/ catalog#', default='')
 
-    description = models.CharField(max_length=400, null=True, blank=True)
+    description = models.CharField(max_length=400, default='')
 
     device_width = models.FloatField(
         verbose_name='width (mm)', null=True, blank=True)
@@ -61,12 +61,12 @@ class Microdevice(LockableModel):
 
     device_fluid_volume = models.FloatField(null=True, blank=True)
     device_fluid_volume_unit = models.CharField(
-        max_length=50, null=True, blank=True)
+        max_length=50, default='')
 
     substrate_thickness = models.FloatField(
         verbose_name='substrate thickness (um)', null=True, blank=True)
     substrate_material = models.CharField(
-        max_length=150, null=True, blank=True)
+        max_length=150, default='')
 
     # Specify whether the device is a plate or a chip
     device_type = models.CharField(max_length=8,
@@ -77,16 +77,14 @@ class Microdevice(LockableModel):
     # (though certain chips appear in a series)
     number_of_rows = models.IntegerField(blank=True,null=True)
     number_of_columns = models.IntegerField(blank=True,null=True)
-    row_labels = models.CharField(blank=True,
-                                  null=True,
+    row_labels = models.CharField(default='',
                                   max_length=1000,
                                   help_text=
                                   'Space separated list of unique labels, '
                                   'e.g. "A B C D ..."'
                                   ' Number of items must match'
                                   ' number of columns.''')
-    column_labels = models.CharField(blank=True,
-                                     null=True,
+    column_labels = models.CharField(default='',
                                      max_length=1000,
                                      help_text='Space separated list of unique '
                                                'labels, e.g. "1 2 3 4 ...". '
@@ -109,7 +107,7 @@ class OrganModel(LockableModel):
     organ = models.ForeignKey('cellsamples.Organ')
     center = models.ForeignKey(MicrophysiologyCenter, null=True, blank=True)
     device = models.ForeignKey(Microdevice, null=True, blank=True)
-    description = models.CharField(max_length=400, null=True, blank=True)
+    description = models.CharField(max_length=400, default='')
 
     protocol = models.FileField(upload_to='protocols', verbose_name='Protocol File',
                             blank=True, null=True, help_text='File detailing the protocols for this model')

--- a/microdevices/models.py
+++ b/microdevices/models.py
@@ -11,8 +11,8 @@ class MicrophysiologyCenter(LockableModel):
 
     center_name = models.CharField(max_length=100)
     center_id = models.CharField(max_length=20,default='-')
-    description = models.CharField(max_length=400, default='')
-    contact_person = models.CharField(max_length=250, default='')
+    description = models.CharField(max_length=400, blank=True, null=True)
+    contact_person = models.CharField(max_length=250, blank=True, null=True)
     center_website = models.URLField(blank=True, null=True)
 
     groups = models.ManyToManyField(Group)
@@ -26,7 +26,7 @@ class Manufacturer(LockableModel):
         ordering = ('manufacturer_name', )
 
     manufacturer_name = models.CharField(max_length=100)
-    contact_person = models.CharField(max_length=250, default='')
+    contact_person = models.CharField(max_length=250, blank=True, null=True)
     Manufacturer_website = models.URLField(blank=True, null=True)
 
     def __unicode__(self):
@@ -43,9 +43,9 @@ class Microdevice(LockableModel):
     center = models.ForeignKey(MicrophysiologyCenter, blank=True, null=True)
     manufacturer = models.ForeignKey(Manufacturer, null=True, blank=True)
     barcode = models.CharField(
-        max_length=200, verbose_name='version/ catalog#', default='')
+        max_length=200, verbose_name='version/ catalog#', null=True, blank=True)
 
-    description = models.CharField(max_length=400, default='')
+    description = models.CharField(max_length=400, null=True, blank=True)
 
     device_width = models.FloatField(
         verbose_name='width (mm)', null=True, blank=True)
@@ -61,12 +61,12 @@ class Microdevice(LockableModel):
 
     device_fluid_volume = models.FloatField(null=True, blank=True)
     device_fluid_volume_unit = models.CharField(
-        max_length=50, default='')
+        max_length=50, null=True, blank=True)
 
     substrate_thickness = models.FloatField(
         verbose_name='substrate thickness (um)', null=True, blank=True)
     substrate_material = models.CharField(
-        max_length=150, default='')
+        max_length=150, null=True, blank=True)
 
     # Specify whether the device is a plate or a chip
     device_type = models.CharField(max_length=8,
@@ -77,14 +77,16 @@ class Microdevice(LockableModel):
     # (though certain chips appear in a series)
     number_of_rows = models.IntegerField(blank=True,null=True)
     number_of_columns = models.IntegerField(blank=True,null=True)
-    row_labels = models.CharField(default='',
+    row_labels = models.CharField(blank=True,
+                                  null=True,
                                   max_length=1000,
                                   help_text=
                                   'Space separated list of unique labels, '
                                   'e.g. "A B C D ..."'
                                   ' Number of items must match'
                                   ' number of columns.''')
-    column_labels = models.CharField(default='',
+    column_labels = models.CharField(blank=True,
+                                     null=True,
                                      max_length=1000,
                                      help_text='Space separated list of unique '
                                                'labels, e.g. "1 2 3 4 ...". '
@@ -107,7 +109,7 @@ class OrganModel(LockableModel):
     organ = models.ForeignKey('cellsamples.Organ')
     center = models.ForeignKey(MicrophysiologyCenter, null=True, blank=True)
     device = models.ForeignKey(Microdevice, null=True, blank=True)
-    description = models.CharField(max_length=400, default='')
+    description = models.CharField(max_length=400, null=True, blank=True)
 
     protocol = models.FileField(upload_to='protocols', verbose_name='Protocol File',
                             blank=True, null=True, help_text='File detailing the protocols for this model')

--- a/mps/static/js/datatable_options.js
+++ b/mps/static/js/datatable_options.js
@@ -1,15 +1,21 @@
 $.fn.dataTable.TableTools.defaults.aButtons = [
     {
         "sExtends": "copy",
-        "sButtonText": "Copy to Clipboard"
+        "sButtonText": "Copy to Clipboard",
+        "mColumns": "sortable",
+        "bFooter": false
     },
     {
         "sExtends": "csv",
-        "sButtonText": "Save as CSV"
+        "sButtonText": "Save as CSV",
+        "mColumns": "sortable",
+        "bFooter": false
     },
     {
         "sExtends": "print",
         "sButtonText": "Print"
+        // Unfortunately it seems columns can not be removed from print in this way
+        //"mColumns": "sortable"
     }
 ];
 $.fn.dataTable.TableTools.defaults.sSwfPath = '/static/swf/copy_csv_xls.swf';

--- a/mps/static/js/inline_add.js
+++ b/mps/static/js/inline_add.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
     });
 
     // This selector will check all items with DELETE in the name, including newly created ones
-    $( "body" ).on( "click", "input[name*='DELETE']", function(event) {
+    $("body").on("click", "input[name*='DELETE']", function(event) {
         // Use a regex to get the desired ID number
         // var thenum = thestring.match(/\d+$/)[0];
         var id = parseInt(event.target.id.match(/\d+/)[0]);
@@ -31,10 +31,7 @@ $(document).ready(function () {
             return;
         }
 
-        // Exit the function if this is an update page (known via hidden div)
-        // Really should just check if original class exists for the given row
-        // Continue only if original class does not exist in the row
-        // TODO scrap odd update hidden div thing
+        // Exit the function if this is an update page (if it has an original, it already exists)
         if ($('#' + title + '-' + id + ' .original')[0]) {
             return;
         }

--- a/mps/templates/assays/assaychipreadout_list.html
+++ b/mps/templates/assays/assaychipreadout_list.html
@@ -41,7 +41,7 @@
             {% for readout in object_list %}
                 <tr class="readout" id={{ readout.id }} name={{ readout.id }}>
                     <td><a class="btn btn-primary" href="{{ readout.id }}">View/Edit</a></td>
-                    <td><a href="{{ readout.id }}">{{ readout.id }}</a></td>
+                    <td>{{ readout.id }}</td>
                     <td><a href="/assays/assaychipsetup/{{ readout.chip_setup.id }}">{{ readout.chip_setup }}</a></td>
                     <td>
                         {% for assay in readout.related_assays %}

--- a/mps/templates/assays/assaychipreadout_list.html
+++ b/mps/templates/assays/assaychipreadout_list.html
@@ -9,6 +9,7 @@
         <table hidden id="readouts" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Readout ID</th>
                     <th>Chip Setup</th>
                     <th>Assays</th>
@@ -23,6 +24,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Readout ID</th>
                     <th>Chip Setup</th>
                     <th>Assays</th>
@@ -38,6 +40,7 @@
             <tbody>
             {% for readout in object_list %}
                 <tr class="readout" id={{ readout.id }} name={{ readout.id }}>
+                    <td><a class="btn btn-primary" href="{{ readout.id }}">View/Edit</a></td>
                     <td><a href="{{ readout.id }}">{{ readout.id }}</a></td>
                     <td><a href="/assays/assaychipsetup/{{ readout.chip_setup.id }}">{{ readout.chip_setup }}</a></td>
                     <td>
@@ -70,7 +73,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on setup not arbitrary ID
-                "order": [[ 1, "asc" ]]
+                "order": [[ 2, "asc" ]],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assaychipsetup_add.html
+++ b/mps/templates/assays/assaychipsetup_add.html
@@ -290,7 +290,8 @@
         </div>
     {% endif %}
 
-    <a id="add_button" class="btn btn-success" role="button">Add Cell Type</a> <span>Click a magnifying glass to see a list of available cell samples. Use 'e' for scientific notation: 1e3 = 1000.</span>
+    <a id="add_button" class="btn btn-success" role="button">Add Cell Type</a>
+    <span>Click a magnifying glass to see a list of available cell samples. Use 'e' for scientific notation: 1e3 = 1000.</span>
     <table class="table table-striped cells" id="assaychipcells_set-group" name="inlines">
         <thead>
             <tr>

--- a/mps/templates/assays/assaychipsetup_list.html
+++ b/mps/templates/assays/assaychipsetup_list.html
@@ -73,6 +73,7 @@
             $('#setups').DataTable( {
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,

--- a/mps/templates/assays/assaychipsetup_list.html
+++ b/mps/templates/assays/assaychipsetup_list.html
@@ -43,7 +43,7 @@
             {% for setup in object_list %}
                 <tr class="compound" id={{ setup.id }} name={{ setup.id }}>
                     <td><a class="btn btn-primary" href="{{ setup.id }}">View/Edit</a></td>
-                    <td><a href="{{ setup.id }}">{{ setup.assay_chip_id }}</a></td>
+                    <td>{{ setup.assay_chip_id }}</td>
                     <td><a href="/assays/organchipstudy/{{ setup.assay_run_id.id }}">{{ setup.assay_run_id }}</a></td>
                     <td>{{ setup.setup_date|date:"M d, Y" }}</td>
                     <td>{{ setup.device }}</td>

--- a/mps/templates/assays/assaychipsetup_list.html
+++ b/mps/templates/assays/assaychipsetup_list.html
@@ -9,6 +9,7 @@
         <table hidden id="setups" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Setup ID / Barcode</th>
                     <th>Study</th>
                     <th>Date</th>
@@ -24,6 +25,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Setup ID / Barcode</th>
                     <th>Study</th>
                     <th>Date</th>
@@ -40,6 +42,7 @@
             <tbody>
             {% for setup in object_list %}
                 <tr class="compound" id={{ setup.id }} name={{ setup.id }}>
+                    <td><a class="btn btn-primary" href="{{ setup.id }}">View/Edit</a></td>
                     <td><a href="{{ setup.id }}">{{ setup.assay_chip_id }}</a></td>
                     <td><a href="/assays/organchipstudy/{{ setup.assay_run_id.id }}">{{ setup.assay_run_id }}</a></td>
                     <td>{{ setup.setup_date|date:"M d, Y" }}</td>
@@ -69,7 +72,13 @@
         $(document).ready(function() {
             $('#setups').DataTable( {
                 dom: 'T<"clear">lfrtip',
-                "iDisplayLength": 50
+                "iDisplayLength": 50,
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assaychiptestresult_add.html
+++ b/mps/templates/assays/assaychiptestresult_add.html
@@ -16,7 +16,7 @@
         <form onsubmit="return confirm('Are you sure you want to overwrite this entry?');" class="form-horizontal" method="post">
 
         <h1>
-            Edit Test Results ID #{{ object.id }}
+            Edit Chip Test Results ID #{{ object.id }}
     {% else %}
         <form class="form-horizontal" method="post" >
 

--- a/mps/templates/assays/assaychiptestresult_list.html
+++ b/mps/templates/assays/assaychiptestresult_list.html
@@ -9,6 +9,7 @@
         <table hidden id="results" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Test Results ID</th>
                     <th>Study</th>
                     <th>Chip Setup</th>
@@ -26,6 +27,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Test Results ID</th>
                     <th>Study</th>
                     <th>Chip Setup</th>
@@ -44,6 +46,7 @@
             <tbody>
             {% for result in object_list %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
+                    <td><a class="btn btn-primary" href="{{ result.assay_result.id }}">View/Edit</a></td>
                     <td>
                         <a href="{{ result.assay_result.id }}">
                             {{ result.assay_result.id }}
@@ -88,7 +91,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on study not arbitrary ID
-                "order": [ 1, "asc" ]
+                "order": [ 2, "asc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assaychiptestresult_list.html
+++ b/mps/templates/assays/assaychiptestresult_list.html
@@ -47,11 +47,7 @@
             {% for result in object_list %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
                     <td><a class="btn btn-primary" href="{{ result.assay_result.id }}">View/Edit</a></td>
-                    <td>
-                        <a href="{{ result.assay_result.id }}">
-                            {{ result.assay_result.id }}
-                        </a>
-                    </td>
+                    <td>{{ result.assay_result.id }}</td>
                     <td>
                         <a href="/assays/organchipstudy/{{ result.assay_result.chip_readout.chip_setup.assay_run_id.id }}">
                             {{ result.assay_result.chip_readout.chip_setup.assay_run_id }}

--- a/mps/templates/assays/assaylayout_list.html
+++ b/mps/templates/assays/assaylayout_list.html
@@ -9,12 +9,14 @@
         <table hidden id="layouts" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Assay Layout Name</th>
                     <th>Device</th>
             </thead>
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Assay Layout Name</th>
                     <th>Device</th>
                 </tr>
@@ -23,6 +25,7 @@
             <tbody>
             {% for layout in object_list %}
                 <tr class="layout" id={{ layout.id }} name={{ layout.id }}>
+                    <td><a class="btn btn-primary" href="{{ layout.id }}">View/Edit</a></td>
                     <td><a href="{{ layout.id }}">{{ layout.layout_name }}</a></td>
                     <td><a href="/microdevices/device/{{ layout.device.id }}">{{ layout.device}}</a></td>
                 </tr>
@@ -37,7 +40,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on start date (descending), not ID
-                "order": [ 1, "asc" ]
+                "order": [ 2, "asc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assaylayout_list.html
+++ b/mps/templates/assays/assaylayout_list.html
@@ -26,7 +26,7 @@
             {% for layout in object_list %}
                 <tr class="layout" id={{ layout.id }} name={{ layout.id }}>
                     <td><a class="btn btn-primary" href="{{ layout.id }}">View/Edit</a></td>
-                    <td><a href="{{ layout.id }}">{{ layout.layout_name }}</a></td>
+                    <td>{{ layout.layout_name }}</td>
                     <td><a href="/microdevices/device/{{ layout.device.id }}">{{ layout.device}}</a></td>
                 </tr>
             {% endfor %}

--- a/mps/templates/assays/assayplatereadout_list.html
+++ b/mps/templates/assays/assayplatereadout_list.html
@@ -9,6 +9,7 @@
         <table hidden id="readouts" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Readout ID</th>
                     <th>Plate Setup</th>
                     <th>Assays</th>
@@ -22,6 +23,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Readout ID</th>
                     <th>Plate Setup</th>
                     <th>Assays</th>
@@ -36,6 +38,7 @@
             <tbody>
             {% for readout in object_list %}
                 <tr class="readout" id={{ readout.id }} name={{ readout.id }}>
+                    <td><a class="btn btn-primary" href="{{ readout.id }}">View/Edit</a></td>
                     <td><a href="{{ readout.id }}">{{ readout.id }}</a></td>
                     <td><a href="/assays/assayplatesetup/{{ readout.setup.id }}">{{ readout.setup }}</a></td>
                     <td>
@@ -68,7 +71,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on setup not arbitrary ID
-                "order": [[ 1, "asc" ]]
+                "order": [[ 2, "asc" ]],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assayplatereadout_list.html
+++ b/mps/templates/assays/assayplatereadout_list.html
@@ -39,7 +39,7 @@
             {% for readout in object_list %}
                 <tr class="readout" id={{ readout.id }} name={{ readout.id }}>
                     <td><a class="btn btn-primary" href="{{ readout.id }}">View/Edit</a></td>
-                    <td><a href="{{ readout.id }}">{{ readout.id }}</a></td>
+                    <td>{{ readout.id }}</td>
                     <td><a href="/assays/assayplatesetup/{{ readout.setup.id }}">{{ readout.setup }}</a></td>
                     <td>
                         {% for assay in readout.related_assays %}

--- a/mps/templates/assays/assayplatesetup_list.html
+++ b/mps/templates/assays/assayplatesetup_list.html
@@ -39,7 +39,7 @@
             {% for setup in object_list %}
                 <tr class="plate-setups" id={{ setup.id }} name={{ setup.id }}>
                     <td><a class="btn btn-primary" href="{{ setup.id }}">View/Edit</a></td>
-                    <td><a href="{{ setup.id }}">{{ setup.assay_plate_id }}</a></td>
+                    <td>{{ setup.assay_plate_id }}</td>
                     <td><a href="/assays/organchipstudy/{{ setup.assay_run_id.id }}">{{ setup.assay_run_id }}</a></td>
                     <td>{{ setup.setup_date|date:"M d, Y" }}</td>
                     <td>{{ setup.assay_layout }}</td>

--- a/mps/templates/assays/assayplatesetup_list.html
+++ b/mps/templates/assays/assayplatesetup_list.html
@@ -62,6 +62,7 @@
             $('#setups').DataTable( {
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,

--- a/mps/templates/assays/assayplatesetup_list.html
+++ b/mps/templates/assays/assayplatesetup_list.html
@@ -9,6 +9,7 @@
         <table hidden id="setups" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Setup ID / Barcode</th>
                     <th>Study</th>
                     <th>Date</th>
@@ -22,6 +23,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Setup ID / Barcode</th>
                     <th>Study</th>
                     <th>Date</th>
@@ -36,6 +38,7 @@
             <tbody>
             {% for setup in object_list %}
                 <tr class="plate-setups" id={{ setup.id }} name={{ setup.id }}>
+                    <td><a class="btn btn-primary" href="{{ setup.id }}">View/Edit</a></td>
                     <td><a href="{{ setup.id }}">{{ setup.assay_plate_id }}</a></td>
                     <td><a href="/assays/organchipstudy/{{ setup.assay_run_id.id }}">{{ setup.assay_run_id }}</a></td>
                     <td>{{ setup.setup_date|date:"M d, Y" }}</td>
@@ -58,7 +61,13 @@
         $(document).ready(function() {
             $('#setups').DataTable( {
                 dom: 'T<"clear">lfrtip',
-                "iDisplayLength": 50
+                "iDisplayLength": 50,
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assayplatetestresult_list.html
+++ b/mps/templates/assays/assayplatetestresult_list.html
@@ -46,12 +46,8 @@
             <tbody>
             {% for result in object_list %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
-                    <td><a class="btn btn-primary" href="{{ result.id }}">View/Edit</a></td>
-                    <td>
-                        <a href="{{ result.assay_result.id }}">
-                            {{ result.assay_result.id }}
-                        </a>
-                    </td>
+                    <td><a class="btn btn-primary" href="{{ result.assay_result.id }}">View/Edit</a></td>
+                    <td>{{ result.assay_result.id }}</td>
                     <td>
                         <a href="/assays/organchipstudy/{{ result.assay_result.readout.setup.assay_run_id.id }}">
                             {{ result.assay_result.readout.setup.assay_run_id }}

--- a/mps/templates/assays/assayplatetestresult_list.html
+++ b/mps/templates/assays/assayplatetestresult_list.html
@@ -9,6 +9,7 @@
         <table hidden id="results" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Test Results ID</th>
                     <th>Study</th>
                     <th>Plate Setup</th>
@@ -26,6 +27,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Test Results ID</th>
                     <th>Study</th>
                     <th>Plate Setup</th>
@@ -44,6 +46,7 @@
             <tbody>
             {% for result in object_list %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
+                    <td><a class="btn btn-primary" href="{{ result.id }}">View/Edit</a></td>
                     <td>
                         <a href="{{ result.assay_result.id }}">
                             {{ result.assay_result.id }}
@@ -88,7 +91,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on study not arbitrary ID
-                "order": [ 1, "asc" ]
+                "order": [ 2, "asc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/assayrun_list.html
+++ b/mps/templates/assays/assayrun_list.html
@@ -37,7 +37,7 @@
             {% for study in object_list %}
                 <tr class="compound" id={{ study.id }} name={{ study.id }}>
                     <td><a class="btn btn-primary" href="{{ study.id }}">View/Edit</a></td>
-                    <td><a href="{{ study.id }}">{{ study.assay_run_id }}</a></td>
+                    <td>{{ study.assay_run_id }}</td>
                     <td>{{ study.study_types }}</td>
                     <td>{{ study.study_configuration }}</td>
                     <td>{{ study.start_date|date:"M d, Y" }}</td>

--- a/mps/templates/assays/assayrun_list.html
+++ b/mps/templates/assays/assayrun_list.html
@@ -9,6 +9,7 @@
         <table hidden id="studies" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Study ID</th>
                     <th>Study Types</th>
                     <th>Study Configuration</th>
@@ -21,6 +22,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Study ID</th>
                     <th>Study Types</th>
                     <th>Study Configuration</th>
@@ -34,6 +36,7 @@
             <tbody>
             {% for study in object_list %}
                 <tr class="compound" id={{ study.id }} name={{ study.id }}>
+                    <td><a class="btn btn-primary" href="{{ study.id }}">View/Edit</a></td>
                     <td><a href="{{ study.id }}">{{ study.assay_run_id }}</a></td>
                     <td>{{ study.study_types }}</td>
                     <td>{{ study.study_configuration }}</td>
@@ -53,7 +56,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on start date (descending), not ID
-                "order": [ 3, "desc" ]
+                "order": [ 4, "desc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/study_index.html
+++ b/mps/templates/assays/study_index.html
@@ -43,7 +43,7 @@
                             View/Edit
                         </a>
                     </td>
-                    <td><a href="/assays/assaychipsetup/{{ setup.id }}/update">{{ setup.assay_chip_id }}</a></td>
+                    <td>{{ setup.assay_chip_id }}</td>
                     <td>{{ setup.setup_date }}</td>
                     <td>{{ setup.device }}</td>
 {#                    <td>{{ setup.chip_test_type }}</td>#}
@@ -90,7 +90,7 @@
                             View/Edit
                         </a>
                     </td>
-                    <td><a href="/assays/assayplatesetup/{{ setup.id }}/update">{{ setup.assay_plate_id }}</a></td>
+                    <td>{{ setup.assay_plate_id }}</td>
                     <td>{{ setup.setup_date }}</td>
                     <td>{{ setup.assay_layout }}</td>
                     <td>{{ setup.created_by }}</td>
@@ -157,7 +157,7 @@
                             View/Edit
                         </a>
                     </td>
-                    <td><a href="/assays/assaychipreadout/{{ readout.id }}/update/">{{ readout.id }}</a></td>
+                    <td>{{ readout.id }}</td>
                     <td><a href="/assays/assaychipsetup/{{ readout.chip_setup.id }}/update/">{{ readout.chip_setup }}</a></td>
                     <td>
                         {% for assay in readout.related_assays %}
@@ -204,7 +204,7 @@
                             View/Edit
                         </a>
                     </td>
-                    <td><a href="/assays/assayplatereadout/{{ readout.id }}/update/">{{ readout.id }}</a></td>
+                    <td>{{ readout.id }}</td>
                     <td><a href="/assays/assayplatesetup/{{ readout.setup.id }}/update/">{{ readout.setup }}</a></td>
                     <td>
                         {% for assay in readout.related_assays %}
@@ -282,9 +282,7 @@
                         </a>
                     </td>
                     <td>
-                        <a href="/assays/assaychiptestresult/{{ result.assay_result.id }}/update/">
-                            {{ result.assay_result.id }}
-                        </a>
+                        {{ result.assay_result.id }}
                     </td>
                     <td>
                         <a href="/assays/assaychipsetup/{{ result.assay_result.chip_readout.chip_setup.id }}/update/">
@@ -345,9 +343,7 @@
                         </a>
                     </td>
                     <td>
-                        <a href="/assays/assayplatetestresult/{{ result.assay_result.id }}/update/">
-                            {{ result.assay_result.id }}
-                        </a>
+                        {{ result.assay_result.id }}
                     </td>
                     <td>
                         <a href="/assays/assayplatesetup/{{ result.assay_result.readout.setup.id }}/update/">

--- a/mps/templates/assays/study_index.html
+++ b/mps/templates/assays/study_index.html
@@ -23,6 +23,7 @@
         <table id="setups" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Setup ID / Barcode</th>
                     <th>Date</th>
                     <th>Organ Model Name</th>
@@ -36,6 +37,12 @@
             <tbody>
             {% for setup in setups %}
                 <tr id={{ setup.id }} name={{ setup.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assaychipsetup/{{ setup.id }}/update">
+                            View/Edit
+                        </a>
+                    </td>
                     <td><a href="/assays/assaychipsetup/{{ setup.id }}/update">{{ setup.assay_chip_id }}</a></td>
                     <td>{{ setup.setup_date }}</td>
                     <td>{{ setup.device }}</td>
@@ -65,6 +72,7 @@
         <table id="plate_setups" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Setup ID / Barcode</th>
                     <th>Date</th>
                     <th>Assay Layout</th>
@@ -76,6 +84,12 @@
             <tbody>
             {% for setup in plate_setups %}
                 <tr id={{ setup.id }} name={{ setup.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assayplatesetup/{{ setup.id }}/update">
+                            View/Edit
+                        </a>
+                    </td>
                     <td><a href="/assays/assayplatesetup/{{ setup.id }}/update">{{ setup.assay_plate_id }}</a></td>
                     <td>{{ setup.setup_date }}</td>
                     <td>{{ setup.assay_layout }}</td>
@@ -124,6 +138,7 @@
         <table id="readouts" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Readout ID</th>
                     <th>Chip Setup</th>
                     <th>Assays</th>
@@ -136,6 +151,12 @@
             <tbody>
             {% for readout in readouts %}
                 <tr id={{ readout.id }} name={{ readout.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assaychipreadout/{{ readout.id }}/update/">
+                            View/Edit
+                        </a>
+                    </td>
                     <td><a href="/assays/assaychipreadout/{{ readout.id }}/update/">{{ readout.id }}</a></td>
                     <td><a href="/assays/assaychipsetup/{{ readout.chip_setup.id }}/update/">{{ readout.chip_setup }}</a></td>
                     <td>
@@ -164,6 +185,7 @@
         <table id="plate_readouts" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Readout ID</th>
                     <th>Plate Setup</th>
                     <th>Assays</th>
@@ -176,6 +198,12 @@
             <tbody>
             {% for readout in plate_readouts %}
                 <tr id={{ readout.id }} name={{ readout.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assayplatereadout/{{ readout.id }}/update/">
+                            View/Edit
+                        </a>
+                    </td>
                     <td><a href="/assays/assayplatereadout/{{ readout.id }}/update/">{{ readout.id }}</a></td>
                     <td><a href="/assays/assayplatesetup/{{ readout.setup.id }}/update/">{{ readout.setup }}</a></td>
                     <td>
@@ -230,6 +258,7 @@
         <table id="results" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Chip Test Results ID</th>
                     <th>Chip Setup</th>
                     <th>Chip Readout ID</th>
@@ -246,6 +275,12 @@
             <tbody>
             {% for result in results %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assaychiptestresult/{{ result.assay_result.id }}/update/">
+                            View/Edit
+                        </a>
+                    </td>
                     <td>
                         <a href="/assays/assaychiptestresult/{{ result.assay_result.id }}/update/">
                             {{ result.assay_result.id }}
@@ -286,6 +321,7 @@
         <table id="results" class="display table table-striped table-hover" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Plate Test Results ID</th>
                     <th>Plate Setup</th>
                     <th>Plate Readout ID</th>
@@ -302,6 +338,12 @@
             <tbody>
             {% for result in plate_results %}
                 <tr class="result" id={{ result.id }} name={{ result.id }}>
+                    <td>
+                        <a class="btn btn-primary"
+                           href="/assays/assayplatetestresult/{{ result.assay_result.id }}/update/">
+                            View/Edit
+                        </a>
+                    </td>
                     <td>
                         <a href="/assays/assayplatetestresult/{{ result.assay_result.id }}/update/">
                             {{ result.assay_result.id }}

--- a/mps/templates/assays/studyconfiguration_add.html
+++ b/mps/templates/assays/studyconfiguration_add.html
@@ -131,6 +131,7 @@
         {% endif %}
 
         <a id="add_button" class="btn btn-success" role="button">Add Model</a>
+        <span>Define model outputs by separating labels with dashes: "AB-CD" means the model is connected to AB and CD</span>
         <table class="table table-striped studymodels" id="studymodel_set-group" name="inlines">
             <thead>
                 <tr>

--- a/mps/templates/assays/studyconfiguration_list.html
+++ b/mps/templates/assays/studyconfiguration_list.html
@@ -9,6 +9,7 @@
         <table hidden id="studyconfigurations" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Name</th>
                     <th>Study Format</th>
                     <th>Media Composition</th>
@@ -18,6 +19,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Name</th>
                     <th>Study Format</th>
                     <th>Media Composition</th>
@@ -28,6 +30,7 @@
             <tbody>
             {% for configuration in object_list %}
                 <tr class="studyconfiguration" id={{ configuration.id }} name={{ configuration.name }}>
+                    <td><a class="btn btn-primary" href="{{ configuration.id }}">View/Edit</a></td>
                     <td><a href="{{ configuration.id }}">{{ configuration.name }}</a></td>
                     <td>{{ configuration.study_format }}</td>
                     <td>{{ configuration.media_composition }}</td>
@@ -42,7 +45,13 @@
         $(document).ready(function() {
             $('#studyconfigurations').DataTable( {
                 dom: 'T<"clear">lfrtip',
-                "iDisplayLength": 50
+                "iDisplayLength": 50,
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/assays/studyconfiguration_list.html
+++ b/mps/templates/assays/studyconfiguration_list.html
@@ -31,7 +31,7 @@
             {% for configuration in object_list %}
                 <tr class="studyconfiguration" id={{ configuration.id }} name={{ configuration.name }}>
                     <td><a class="btn btn-primary" href="{{ configuration.id }}">View/Edit</a></td>
-                    <td><a href="{{ configuration.id }}">{{ configuration.name }}</a></td>
+                    <td>{{ configuration.name }}</td>
                     <td>{{ configuration.study_format }}</td>
                     <td>{{ configuration.media_composition }}</td>
                     <td>{{ configuration.hardware_description }}</td>

--- a/mps/templates/assays/studyconfiguration_list.html
+++ b/mps/templates/assays/studyconfiguration_list.html
@@ -46,6 +46,7 @@
             $('#studyconfigurations').DataTable( {
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,

--- a/mps/templates/base.html
+++ b/mps/templates/base.html
@@ -146,6 +146,7 @@
                       <li title="View curated drug trial data"><a href="/drugtrials">View Drug Trials</a></li>
                       <li><a href="/compounds/">View Chemical Data</a></li>
                       <li><a href="/adverse_events/">View Adverse Events</a></li>
+                      <li><a href="/compounds/report/#filter">Compound Report</a></li>
                       <li class="divider"></li>
                       <li class="dropdown-header">Requires Permission</li>
                       <li><a href="/compounds/add">Add Compound</a></li>

--- a/mps/templates/base.html
+++ b/mps/templates/base.html
@@ -40,7 +40,7 @@
         <script src="{% static "js/modernizr-2.7.1.js" %}"></script>
 
         <!-- d3.js Library -->
-        <script src="{% static "js/d3.v3.min.js" %}"></script>
+        <script src="{% static "js/d3.min.js" %}"></script>
 
         <!-- Load c3.css -->
         <link href="{% static "css/c3.css" %}" rel="stylesheet" type="text/css">

--- a/mps/templates/base.html
+++ b/mps/templates/base.html
@@ -165,9 +165,9 @@
               <li title="Analyze bioactivity data" class="dropdown">
                 <a class="dropdown-toggle">Bioactivities<span class="caret"></span></a>
                   <ul class="dropdown-menu" role="menu">
-                      <li title="View a table of bioactivities based on your selection"><a href="/bioactivities/table">View Bioactivities</a></li>
-                      <li title="Generate a heatmap for selected bioactivity data"><a href="/bioactivities/heatmap">Heatmap</a></li>
-                      <li title="Generate a dendrogram for selected compound/bioactivity data"><a href="/bioactivities/cluster">Cluster</a></li>
+                      <li title="View a table of bioactivities based on your selection"><a href="/bioactivities/table/#filter">View Bioactivities</a></li>
+                      <li title="Generate a heatmap for selected bioactivity data"><a href="/bioactivities/heatmap/#filter">Heatmap</a></li>
+                      <li title="Generate a dendrogram for selected compound/bioactivity data"><a href="/bioactivities/cluster/#filter">Cluster</a></li>
                   </ul>
               </li>
               <li title="Give feedback, ask questions, or view the knowledge base"><a style="color: rgb(0,0,255)" onclick="window.open('/feedback/', 'win', 'toolbars=0,width=1000,height=760,left=200,top=200,scrollbars=1,resizable=1')">Feedback</a></li>

--- a/mps/templates/bioactivities/bioactivities_list.html
+++ b/mps/templates/bioactivities/bioactivities_list.html
@@ -62,6 +62,7 @@
                     {% else %}
                         <th>Activity Name</th>
                         <th>Value (μM)</th>
+                        <th>Outcome</th>
                         <th>PubChem Link</th>
                     {% endif %}
                 </tr>
@@ -71,7 +72,7 @@
             {% for bioactivity in bioactivities %}
                 <tr>
                     <td><a href="/compounds/{{ bioactivity.compound.id }}">{{ bioactivity.compound }}</a></td>
-                    <td>{{ bioactivity.target|default:'' }}</td>
+                    <td>{{ bioactivity.assay.target|default:'' }}</td>
                     {% if not pubchem %}
                         <td>{{ bioactivity.organism }}</td>
                         <td>{{ bioactivity.standard_name }}</td>
@@ -82,11 +83,12 @@
                             {{ bioactivity.assay.chemblid }}
                         </a></td>
                     {% else %}
-                        <td>{{ bioactivity.target.organism|default:bioactivity.assay.organism|default:'' }}</td>
+                        <td>{{ bioactivity.assay.target.organism|default:bioactivity.assay.organism|default:'' }}</td>
                         <td>{{ bioactivity.activity_name }}</td>
                         <td>{{ bioactivity.value }}</td>
-                        <td><a href="https://pubchem.ncbi.nlm.nih.gov/assay/assay.cgi?aid={{ bioactivity.assay.aid }}">
-                            {{ bioactivity.assay.aid|default:'' }}
+                        <td>{{ bioactivity.outcome }}</td>
+                        <td><a href="https://pubchem.ncbi.nlm.nih.gov/assay/assay.cgi?aid={{ bioactivity.assay.pubchem_id }}">
+                            {{ bioactivity.assay.pubchem_id|default:'' }}
                         </a></td>
                     {% endif %}
                 </tr>

--- a/mps/templates/bioactivities/bioactivities_list.html
+++ b/mps/templates/bioactivities/bioactivities_list.html
@@ -43,6 +43,7 @@
                     {% else %}
                         <th>Activity Name</th>
                         <th>Value (μM)</th>
+                        <th>Outcome</th>
                         <th>PubChem Link</th>
                     {% endif %}
                 </tr>

--- a/mps/templates/bioactivities/cluster.html
+++ b/mps/templates/bioactivities/cluster.html
@@ -382,7 +382,7 @@
 
     {% block spinner %}
         <script>
-            // define a spinner but do not show it yet
+        // define a spinner but do not show it yet
 
         window.spinner = new Spinner(
             {

--- a/mps/templates/bioactivities/cluster.html
+++ b/mps/templates/bioactivities/cluster.html
@@ -28,9 +28,9 @@
         <div class="row">
             <div class="text-center">
                 {% block submit %}
-                <button type="button" class="btn btn-xlarge btn-primary text-center" id="submit">
+                <a href="#show" class="btn btn-xlarge btn-primary text-center" id="submit">
                     Generate Dendrogram
-                </button>
+                </a>
                 {% endblock %}
             </div>
         </div>
@@ -416,10 +416,10 @@
 
         <div hidden id="graphic">
             <div class="row text-center">
-                <button id="back" class="btn btn-xlarge btn-info">
+                <a href="#filter" id="back" class="btn btn-xlarge btn-info">
                     <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>
                     Back to Selection
-                </button>
+                </a>
             </div>
 
             <hr>

--- a/mps/templates/bioactivities/cluster.html
+++ b/mps/templates/bioactivities/cluster.html
@@ -109,7 +109,7 @@
                         <tbody id="control_target_types">
                             <tr>
                                 <td>
-                                    <input value="Cell-Line" id="Cell-Line" type="checkbox">
+                                    <input value="CELL-LINE" id="Cell-Line" type="checkbox">
                                 </td>
                                 <td>
                                     Cell-Line
@@ -117,7 +117,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input value="Organism" id="Organism" type="checkbox">
+                                    <input value="ORGANISM" id="Organism" type="checkbox">
                                 </td>
                                 <td>
                                     Organism
@@ -125,7 +125,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input value="Single Protein" id="Single_Protein" type="checkbox" checked>
+                                    <input value="SINGLE PROTEIN" id="Single_Protein" type="checkbox" checked>
                                 </td>
                                 <td>
                                     Single Protein
@@ -163,26 +163,26 @@
                         <tbody id="control_organisms">
                             <tr>
                                 <td>
-                                    <input value="Canis Lupus Familiaris" id="Canis_Lupus_Familiaris" type="checkbox">
+                                    <input value="Canis lupus familiaris" id="Canis_Lupus_Familiaris" type="checkbox">
                                 </td>
                                 <td>
-                                    Canis Lupus Familiaris
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <input value="Homo Sapiens" id="Homo_Sapiens" type="checkbox" checked>
-                                </td>
-                                <td>
-                                    Homo Sapiens
+                                    Canis lupus familiaris
                                 </td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input value="Rattus Norvegicus" id="Rattus_Norvegicus" type="checkbox" checked>
+                                    <input value="Homo sapiens" id="Homo_Sapiens" type="checkbox" checked>
                                 </td>
                                 <td>
-                                    Rattus Norvegicus
+                                    Homo sapiens
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input value="Rattus norvegicus" id="Rattus_Norvegicus" type="checkbox" checked>
+                                </td>
+                                <td>
+                                    Rattus norvegicus
                                 </td>
                             </tr>
                         </tbody>

--- a/mps/templates/bioactivities/heatmap.html
+++ b/mps/templates/bioactivities/heatmap.html
@@ -8,9 +8,9 @@
 {% endblock %}
 
 {% block submit %}
-    <button type="button" class="btn btn-xlarge btn-primary text-center" id="submit">
+    <a href="#show" class="btn btn-xlarge btn-primary text-center" id="submit">
         Generate Heatmap
-    </button>
+    </a>
 {% endblock %}
 
 {% block extra_row %}
@@ -65,10 +65,10 @@
 {% block graphic %}
     <div hidden id="graphic">
         <div class="row text-center">
-            <button id="back" class="btn btn-xlarge btn-info">
+            <a href="#filter" id="back" class="btn btn-xlarge btn-info">
                 <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>
                 Back to Selection
-            </button>
+            </a>
             <a id="download" class="btn btn-xlarge btn-primary">Download Heatmap</a>
         </div>
 

--- a/mps/templates/bioactivities/table.html
+++ b/mps/templates/bioactivities/table.html
@@ -11,7 +11,7 @@
 
     <legend><h1>Quick Search</h1></legend>
 
-    <form action="/bioactivities/table/" method="post">
+    <form action="/bioactivities/table/#filter" method="post">
         {% csrf_token %}
         {{ form.app.as_hidden }}
         {{ form.search_term.as_hidden }}
@@ -20,9 +20,9 @@
 
     <legend><h1>Advanced Search</h1></legend>
 
-    <button type="button" class="btn btn-xlarge btn-primary text-center" id="submit">
+    <a href="#show" type="button" class="btn btn-xlarge btn-primary text-center" id="submit">
         Generate Table
-    </button>
+    </a>
 {% endblock %}
 
 {% block extra_row %}
@@ -131,10 +131,10 @@
 {% block graphic %}
     <div hidden id="graphic" style="padding-bottom: 50px" class="container">
         <div class="row text-center">
-            <button id="back" class="btn btn-xlarge btn-info">
+            <a href="#filter"  id="back" class="btn btn-xlarge btn-info">
                 <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>
                 Back to Selection
-            </button>
+            </a>
 {#            <a id="download" class="btn btn-xlarge btn-primary">Download Table</a>#}
         </div>
 

--- a/mps/templates/bioactivities/table.html
+++ b/mps/templates/bioactivities/table.html
@@ -156,14 +156,10 @@
                     <th>Compound</th>
                     <th>Target</th>
                     <th>Organism</th>
-                    <th>Standard Name</th>
-                    <th>Operator</th>
-                    <th>Standard Value</th>
-                    <th>Standard Units</th>
+                    <th>Activity Name</th>
+                    <th>Standard Value (μm)</th>
                     <th>ChEMBL Link</th>
-{#                    <th>ChEMBL Name</th>#}
-{#                    <th>ChEMBL Value</th>#}
-{#                    <th>ChEMBL Units</th>#}
+                    <th>PubChem Link</th>
                 </tr>
             </thead>
 
@@ -172,14 +168,10 @@
                     <th>Compound</th>
                     <th>Target</th>
                     <th>Organism</th>
-                    <th>Standard Name</th>
-                    <th>Operator</th>
-                    <th>Standard Value</th>
-                    <th>Standard Units</th>
+                    <th>Activity Name</th>
+                    <th>Standard Value (μm)</th>
                     <th>ChEMBL Link</th>
-{#                    <th>ChEMBL Name</th>#}
-{#                    <th>ChEMBL Value</th>#}
-{#                    <th>ChEMBL Units</th>#}
+                    <th>PubChem Link</th>
                 </tr>
             </tfoot>
 

--- a/mps/templates/cellsamples/cellsample_list.html
+++ b/mps/templates/cellsamples/cellsample_list.html
@@ -9,6 +9,7 @@
         <table hidden id="cellsamples" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>ID #</th>
                     <th>Receipt Date</th>
                     <th>Barcode/Lot #</th>
@@ -22,6 +23,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>ID #</th>
                     <th>Receipt Date</th>
                     <th>Barcode/Lot #</th>
@@ -36,6 +38,7 @@
             <tbody>
             {% for cellsample in object_list %}
                 <tr class="cellsample" id={{ cellsample.id }} name={{ cellsample }}>
+                    <td><a class="btn btn-primary" href="{{ cellsample.id }}">View/Edit</a></td>
                     {# May seem odd, but including the id can help demystify the ID that appears in add interface #}
                     <td><a href="{{ cellsample.id }}">{{ cellsample.id }}</a></td>
                     {# Adding a link to this row converts it from date to HTML = Really, REALLY annoying #}
@@ -63,7 +66,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on receipt date
-                "order": [ 1, "desc" ]
+                "order": [ 2, "desc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/cellsamples/cellsample_list.html
+++ b/mps/templates/cellsamples/cellsample_list.html
@@ -40,7 +40,7 @@
                 <tr class="cellsample" id={{ cellsample.id }} name={{ cellsample }}>
                     <td><a class="btn btn-primary" href="{{ cellsample.id }}">View/Edit</a></td>
                     {# May seem odd, but including the id can help demystify the ID that appears in add interface #}
-                    <td><a href="{{ cellsample.id }}">{{ cellsample.id }}</a></td>
+                    <td>{{ cellsample.id }}</td>
                     {# Adding a link to this row converts it from date to HTML = Really, REALLY annoying #}
                     <td>{{ cellsample.receipt_date|date:"M d, Y" }}</td>
                     <td>{{ cellsample.barcode }}</td>

--- a/mps/templates/cellsamples/celltype_list.html
+++ b/mps/templates/cellsamples/celltype_list.html
@@ -9,6 +9,7 @@
         <table hidden id="celltypes" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Organ</th>
                     <th>Cell Type</th>
                     <th>Cell Subtype</th>
@@ -18,6 +19,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View/Edit</th>
                     <th>Organ</th>
                     <th>Cell Type</th>
                     <th>Cell Subtype</th>
@@ -28,6 +30,7 @@
             <tbody>
             {% for celltype in object_list %}
                 <tr class="cellsample" id={{ celltype.id }} name={{ celltype }}>
+                    <td><a class="btn btn-primary" href="{{ celltype.id }}">View/Edit</a></td>
                     <td><a href="{{ celltype.id }}">{{ celltype.organ }}</a></td>
                     <td><a href="{{ celltype.id }}">{{ celltype.cell_type }}</a></td>
                     <td>{{ celltype.cell_subtype }}</td>
@@ -44,7 +47,13 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on organ
-                "order": [ 0, "asc" ]
+                "order": [ 2, "asc" ],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/cellsamples/celltype_list.html
+++ b/mps/templates/cellsamples/celltype_list.html
@@ -31,7 +31,7 @@
             {% for celltype in object_list %}
                 <tr class="cellsample" id={{ celltype.id }} name={{ celltype }}>
                     <td><a class="btn btn-primary" href="{{ celltype.id }}">View/Edit</a></td>
-                    <td><a href="{{ celltype.id }}">{{ celltype.organ }}</a></td>
+                    <td>{{ celltype.organ }}</td>
                     <td><a href="{{ celltype.id }}">{{ celltype.cell_type }}</a></td>
                     <td>{{ celltype.cell_subtype }}</td>
                     <td>{{ celltype.species }}</td>

--- a/mps/templates/compounds/compounds_detail.html
+++ b/mps/templates/compounds/compounds_detail.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{# TODO REQUIRES MAJOR AESTHETIC REVISION #}
+
 {% block content %}
     <style>
     p {
@@ -225,4 +227,33 @@
             </div>
         </div>
     </div>
+
+    {% if object.compoundproperty_set.all %}
+        <legend>Additional Properties</legend>
+        <table class="table table-striped table-bordered" style="width: auto;">
+            <tbody>
+            {% for property in object.compoundproperty_set.all %}
+                <tr>
+                    <td><strong>{{ property.property }}</strong></td>
+                    <td>{{ property.value }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    {% if object.compoundsummary_set.all %}
+        <legend>Summary</legend>
+        <table class="table table-striped table-bordered">
+            <tbody>
+            {% for summary in object.compoundsummary_set.all %}
+                <tr>
+                    <td><strong>{{ summary.summary_type }}</strong></td>
+                    <td>{{ summary.summary }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
 {% endblock %}

--- a/mps/templates/compounds/compounds_detail.html
+++ b/mps/templates/compounds/compounds_detail.html
@@ -234,7 +234,7 @@
             <tbody>
             {% for property in object.compoundproperty_set.all %}
                 <tr>
-                    <td><strong>{{ property.property }}</strong></td>
+                    <td><strong>{{ property.property_type }}</strong></td>
                     <td>{{ property.value }}</td>
                 </tr>
             {% endfor %}

--- a/mps/templates/compounds/compounds_list.html
+++ b/mps/templates/compounds/compounds_list.html
@@ -9,6 +9,7 @@
         <table hidden id="compounds" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View</th>
                     <th>Name</th>
                     <th>CHEMBL ID</th>
                     <th>Synonyms</th>
@@ -24,6 +25,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View</th>
                     <th>Name</th>
                     <th>CHEMBL ID</th>
                     <th>Synonyms</th>
@@ -40,6 +42,7 @@
             <tbody>
             {% for compound in object_list %}
                 <tr class="compound" id={{ compound.id }} name={{ compound.name }}>
+                    <td><a class="btn btn-primary" href="{{ compound.id }}">View</a></td>
                     <td><a href="{{ compound.id }}">{{ compound.name }}</a></td>
                     <td><a href="https://www.ebi.ac.uk/chembl/compound/inspect/{{ compound.chemblid }}">{{ compound.chemblid }}</a></td>
                     <td>{{ compound.synonyms }}</td>
@@ -66,10 +69,10 @@
                 "aoColumnDefs": [
                     {
                         "bSortable": false,
-                        "aTargets": [8]
+                        "aTargets": [0,9]
                     },
                     {
-                        "targets": [2],
+                        "targets": [3],
                         "visible": false,
                         "searchable": true
                     }

--- a/mps/templates/compounds/compounds_list.html
+++ b/mps/templates/compounds/compounds_list.html
@@ -66,6 +66,7 @@
         $(document).ready(function() {
             $('#compounds').DataTable({
                 dom: 'T<"clear">lfrtip',
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,

--- a/mps/templates/compounds/compounds_list.html
+++ b/mps/templates/compounds/compounds_list.html
@@ -43,7 +43,7 @@
             {% for compound in object_list %}
                 <tr class="compound" id={{ compound.id }} name={{ compound.name }}>
                     <td><a class="btn btn-primary" href="{{ compound.id }}">View</a></td>
-                    <td><a href="{{ compound.id }}">{{ compound.name }}</a></td>
+                    <td>{{ compound.name }}</td>
                     <td><a href="https://www.ebi.ac.uk/chembl/compound/inspect/{{ compound.chemblid }}">{{ compound.chemblid }}</a></td>
                     <td>{{ compound.synonyms }}</td>
                     <td>{{ compound.molecular_weight|default_if_none:"" }}</td>

--- a/mps/templates/compounds/compounds_list.html
+++ b/mps/templates/compounds/compounds_list.html
@@ -10,6 +10,7 @@
             <thead>
                 <tr>
                     <th>View</th>
+                    <th>Edit</th>
                     <th>Name</th>
                     <th>CHEMBL ID</th>
                     <th>Synonyms</th>
@@ -26,6 +27,7 @@
             <tfoot>
                 <tr>
                     <th>View</th>
+                    <th>Edit</th>
                     <th>Name</th>
                     <th>CHEMBL ID</th>
                     <th>Synonyms</th>
@@ -43,6 +45,7 @@
             {% for compound in object_list %}
                 <tr class="compound" id={{ compound.id }} name={{ compound.name }}>
                     <td><a class="btn btn-primary" href="{{ compound.id }}">View</a></td>
+                    <td><a class="btn btn-primary" href="{{ compound.id }}/update/">Edit</a></td>
                     <td>{{ compound.name }}</td>
                     <td><a href="https://www.ebi.ac.uk/chembl/compound/inspect/{{ compound.chemblid }}">{{ compound.chemblid }}</a></td>
                     <td>{{ compound.synonyms }}</td>
@@ -66,14 +69,14 @@
         $(document).ready(function() {
             $('#compounds').DataTable({
                 dom: 'T<"clear">lfrtip',
-                "order": [[ 1, "asc" ]],
+                "order": [[ 2, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,
-                        "aTargets": [0,9]
+                        "aTargets": [0,1,10]
                     },
                     {
-                        "targets": [3],
+                        "targets": [4],
                         "visible": false,
                         "searchable": true
                     }

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -147,10 +147,10 @@
                 <tr>
                     <th>Compound</th>
                     <th>Dose (xCmax)</th>
-{#                    <th>cLogP</th>#}
+                    <th>cLogP</th>
                     <th>Pre-clinical Findings</th>
                     <th>Clinical Findings</th>
-{#                    <th>Adverse Events</th>#}
+                    <th>PK/Metabolism</th>
                     <th>Organ Model Results</th>
                 </tr>
             </thead>

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -132,7 +132,7 @@
 
     {# Right now the fields of a report are static, but that will likely change #}
     {# Need to switch to hide full #}
-    <div id="graphic" style="padding-bottom: 50px">
+    <div hidden id="graphic" style="padding-bottom: 50px">
         <div class="row text-center">
             <a href="#filter"  id="back" class="btn btn-xlarge btn-info">
                 <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>
@@ -142,7 +142,7 @@
 
         <hr>
 
-        <table hidden class="display" id="results_table" cellspacing="0" width="100%">
+        <table class="display" id="results_table" cellspacing="0" width="100%">
             <thead>
                 <tr>
                     <th>Compound</th>

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -9,6 +9,14 @@
 
 {% block content %}
 
+    <style>
+        .sparkline {
+            fill: none;
+            stroke: #000;
+            stroke-width: 0.5px;
+        }
+    </style>
+
     <div id="selection" style="padding-bottom: 50px">
         <div class="row">
             <div class="text-center">
@@ -125,6 +133,15 @@
     {# Right now the fields of a report are static, but that will likely change #}
     {# Need to switch to hide full #}
     <div id="graphic" style="padding-bottom: 50px">
+        <div class="row text-center">
+            <a href="#filter"  id="back" class="btn btn-xlarge btn-info">
+                <span class="glyphicon glyphicon-hand-left" aria-hidden="true"></span>
+                Back to Selection
+            </a>
+        </div>
+
+        <hr>
+
         <table hidden class="display" id="results_table" cellspacing="0" width="100%">
             <thead>
                 <tr>

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -155,18 +155,6 @@
                 </tr>
             </thead>
 
-            <tfoot>
-                <tr>
-                    <th>Compound</th>
-                    <th>Dose (xCmax)</th>
-                    <th>cLogP</th>
-                    <th>Pre-clinical Findings</th>
-                    <th>Clinical Findings</th>
-                    <th>Adverse Events</th>
-                    <th>Organ Model Results</th>
-                </tr>
-            </tfoot>
-
             <tbody id="results_body">
             </tbody>
         </table>

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -1,0 +1,157 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block load %}
+    <script src="{% static "compounds/compound_report.js" %}"></script>
+    <script src="{% static "js/spin.min.js" %}"></script>
+    <script src="{% static "js/cookies.js" %}"></script>
+{% endblock %}
+
+{% block content %}
+
+    <div id="selection" style="padding-bottom: 50px">
+        <div class="row">
+            <div class="text-center">
+                {% block submit %}
+                <a href="#show" class="btn btn-xlarge btn-primary text-center" id="submit">
+                    Generate Compound Report
+                </a>
+                {% endblock %}
+            </div>
+        </div>
+        <hr>
+
+        <table hidden id="compounds" class="display" cellspacing="0" width="100%">
+            <thead>
+                <tr>
+                    <th>Select</th>
+                    <th>Name</th>
+                    <th>CHEMBL ID</th>
+                    <th>Synonyms</th>
+                    <th>Molecular Weight</th>
+                    <th>LogP</th>
+                    <th>Rule of 5 Violations</th>
+                    <th>Known Drug</th>
+                    <th>Tags</th>
+                    <th>Image</th>
+                </tr>
+            </thead>
+
+            <tfoot>
+                <tr>
+                    <th>Select</th>
+                    <th>Name</th>
+                    <th>CHEMBL ID</th>
+                    <th>Synonyms</th>
+                    <th>Molecular Weight</th>
+                    <th>LogP</th>
+                    <th>Rule of 5 Violations</th>
+                    <th>Known Drug</th>
+                    <th>Tags</th>
+                    <th>Image</th>
+                </tr>
+            </tfoot>
+
+            <tbody>
+            <form autocomplete="off">
+            {% for compound in object_list %}
+                <tr class="compound" id={{ compound.id }} name={{ compound.name }}>
+                    {# Checkbox for each compound #}
+                    <td><input class="checkbox" type="checkbox" value="{{ compound.name|safe }}"></td>
+                    <td><a href="/compounds/{{ compound.id }}">{{ compound.name }}</a></td>
+                    <td><a href="https://www.ebi.ac.uk/chembl/compound/inspect/{{ compound.chemblid }}">{{ compound.chemblid }}</a></td>
+                    <td>{{ compound.synonyms }}</td>
+                    <td>{{ compound.molecular_weight|default_if_none:"" }}</td>
+                    <td>{{ compound.logp|default_if_none:"" }}</td>
+                    <td>{{ compound.ro5_violations|default_if_none:"" }}</td>
+                    <td>{{ compound.known_drug }}</td>
+                    <td>{{ compound.tags|default_if_none:"" }}</td>
+                    <td><img src="https://www.ebi.ac.uk/chembldb/compound/displayimage/{{ compound.chemblid }}"></td>
+                </tr>
+            {% endfor %}
+            </form>
+            </tbody>
+        </table>
+    </div>
+
+    <script>
+        $(document).ready(function() {
+            $('#compounds').DataTable({
+                dom: 'T<"clear">lfrtip',
+                "order": [[ 1, "asc" ]],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0,9]
+                    },
+                    {
+                        "targets": [3],
+                        "visible": false,
+                        "searchable": true
+                    }
+                ],
+                "iDisplayLength": 25
+            });
+        });
+
+        // define a spinner but do not show it yet
+
+        window.spinner = new Spinner(
+            {
+                lines: 11, // The number of lines to draw
+                length: 40, // The length of each line
+                width: 15, // The line thickness
+                radius: 42, // The radius of the inner circle
+                corners: 1, // Corner roundness (0..1)
+                rotate: 0, // The rotation offset
+                direction: 1, // 1: clockwise, -1: counterclockwise
+                color: '#000', // #rgb or #rrggbb or array of colors
+                speed: 1.2, // Rounds per second
+                trail: 100, // Afterglow percentage
+                shadow: true, // Whether to render a shadow
+                hwaccel: true, // Whether to use hardware acceleration
+                className: 'spinner', // The CSS class to assign to the spinner
+                zIndex: 2e9, // The z-index (defaults to 2000000000)
+                top: '50%', // Top position relative to parent
+                left: '50%' // Left position relative to parent
+            }
+        );
+    </script>
+
+    <script src="{% static "js/display_datatable.js" %}"></script>
+
+    <div id="spinner"></div>
+
+    {# Right now the fields of a report are static, but that will likely change #}
+    {# Need to switch to hide full #}
+    <div id="graphic" style="padding-bottom: 50px">
+        <table hidden class="display" id="results_table" cellspacing="0" width="100%">
+            <thead>
+                <tr>
+                    <th>Compound</th>
+                    <th>Dose (xCmax)</th>
+                    <th>cLogP</th>
+                    <th>Pre-clinical Findings</th>
+                    <th>Clinical Findings</th>
+                    <th>Adverse Events</th>
+                    <th>Organ Model Results</th>
+                </tr>
+            </thead>
+
+            <tfoot>
+                <tr>
+                    <th>Compound</th>
+                    <th>Dose (xCmax)</th>
+                    <th>cLogP</th>
+                    <th>Pre-clinical Findings</th>
+                    <th>Clinical Findings</th>
+                    <th>Adverse Events</th>
+                    <th>Organ Model Results</th>
+                </tr>
+            </tfoot>
+
+            <tbody id="results_body">
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -147,10 +147,10 @@
                 <tr>
                     <th>Compound</th>
                     <th>Dose (xCmax)</th>
-                    <th>cLogP</th>
+{#                    <th>cLogP</th>#}
                     <th>Pre-clinical Findings</th>
                     <th>Clinical Findings</th>
-                    <th>Adverse Events</th>
+{#                    <th>Adverse Events</th>#}
                     <th>Organ Model Results</th>
                 </tr>
             </thead>

--- a/mps/templates/compounds/compounds_report.html
+++ b/mps/templates/compounds/compounds_report.html
@@ -12,8 +12,8 @@
     <style>
         .sparkline {
             fill: none;
-            stroke: #000;
-            stroke-width: 0.5px;
+            stroke: #FF2400;
+            stroke-width: 0.75px;
         }
     </style>
 

--- a/mps/templates/compounds/compounds_update.html
+++ b/mps/templates/compounds/compounds_update.html
@@ -86,7 +86,7 @@
         </thead>
         <tbody>
             {% for summary in formset_summary %}
-                <tr class="inline" id="property-{{ forloop.counter0 }}">
+                <tr class="inline" id="summary-{{ forloop.counter0 }}">
                     {# Hidden input for Update (need id to associate) #}
                     {% if summary.id.value %}
                     <td class="original" hidden>

--- a/mps/templates/compounds/compounds_update.html
+++ b/mps/templates/compounds/compounds_update.html
@@ -2,7 +2,6 @@
 {% load static %}
 
 {% block load %}
-    <script src="{% static "compounds/compound_report.js" %}"></script>
     <script src="{% static "js/enter_override.js" %}"></script>
     <script src="{% static "compounds/compound_update.js" %}"></script>
 {% endblock %}

--- a/mps/templates/compounds/compounds_update.html
+++ b/mps/templates/compounds/compounds_update.html
@@ -40,6 +40,7 @@
             <tr>
                 <th>Property</th>
                 <th>Value</th>
+                <th>Source</th>
                 <th>Delete</th>
             </tr>
         </thead>
@@ -54,6 +55,7 @@
                     {% endif %}
                     <td>{{ property.property_type }}</td>
                     <td>{{ property.value }}</td>
+                    <td>{{ property.source }}</td>
                     <td>{{ property.DELETE }}</td>
                 </tr>
             {% endfor %}
@@ -81,6 +83,7 @@
             <tr>
                 <th>Summary Type</th>
                 <th>Summary</th>
+                <th>Source</th>
                 <th>Delete</th>
             </tr>
         </thead>
@@ -95,6 +98,7 @@
                     {% endif %}
                     <td>{{ summary.summary_type }}</td>
                     <td>{{ summary.summary }}</td>
+                    <td>{{ summary.source }}</td>
                     <td>{{ summary.DELETE }}</td>
                 </tr>
             {% endfor %}

--- a/mps/templates/compounds/compounds_update.html
+++ b/mps/templates/compounds/compounds_update.html
@@ -53,7 +53,7 @@
                         <input id="id_compoundproperty_set-{{ forloop.counter0 }}-id" name="compoundproperty_set-{{ forloop.counter0 }}-id" type="hidden" value="{{ property.id.value }}">
                     </td>
                     {% endif %}
-                    <td>{{ property.property }}</td>
+                    <td>{{ property.property_type }}</td>
                     <td>{{ property.value }}</td>
                     <td>{{ property.DELETE }}</td>
                 </tr>

--- a/mps/templates/compounds/compounds_update.html
+++ b/mps/templates/compounds/compounds_update.html
@@ -1,0 +1,107 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block load %}
+    <script src="{% static "compounds/compound_report.js" %}"></script>
+    <script src="{% static "js/enter_override.js" %}"></script>
+    <script src="{% static "compounds/compound_update.js" %}"></script>
+{% endblock %}
+
+{% block content %}
+
+<form onsubmit="return confirm('Are you sure you want to overwrite this entry?');" enctype="multipart/form-data" class="form-horizontal" method="post">
+
+    {% csrf_token %}
+    {{ formset_summary.management_form }}
+    {{ formset_property.management_form }}
+    <h1>
+        Edit {{ object }} Summaries and Additional Properties
+
+        <button id="submit" type="submit" class="btn btn-primary">Submit</button>
+    </h1>
+
+    <legend>Additional Properties</legend>
+    {% if formset_property.errors %}
+        {% for dict in formset_property.errors %}
+            {% for key,value in dict.items %}
+                {% if key %}
+                    <div class="alert alert-danger" role="alert">
+                        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                        <span class="sr-only">Error:</span>
+                        {{ forloop.parentloop.counter }}.) {{ key }} : {{ value }}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
+    <a id="add_button_property" class="btn btn-success" role="button">Add Additional Property</a>
+    <table class="table table-striped assays" id="compoundproperty_set-group"  name="inlines_property">
+        <thead>
+            <tr>
+                <th>Property</th>
+                <th>Value</th>
+                <th>Delete</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for property in formset_property %}
+                <tr class="inline" id="property-{{ forloop.counter0 }}">
+                    {# Hidden input for Update (need id to associate) #}
+                    {% if property.id.value %}
+                    <td class="original" hidden>
+                        <input id="id_compoundproperty_set-{{ forloop.counter0 }}-id" name="compoundproperty_set-{{ forloop.counter0 }}-id" type="hidden" value="{{ property.id.value }}">
+                    </td>
+                    {% endif %}
+                    <td>{{ property.property }}</td>
+                    <td>{{ property.value }}</td>
+                    <td>{{ property.DELETE }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <legend>Summaries</legend>
+    {% if formset_summary.errors %}
+        {% for dict in formset_summary.errors %}
+            {% for key,value in dict.items %}
+                {% if key %}
+                    <div class="alert alert-danger" role="alert">
+                        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                        <span class="sr-only">Error:</span>
+                        {{ forloop.parentloop.counter }}.) {{ key }} : {{ value }}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
+    <a id="add_button_summary" class="btn btn-success" role="button">Add Summary</a>
+    <table class="table table-striped assays" id="compoundsummary_set-group"  name="inlines_summary">
+        <thead>
+            <tr>
+                <th>Summary Type</th>
+                <th>Summary</th>
+                <th>Delete</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for summary in formset_summary %}
+                <tr class="inline" id="property-{{ forloop.counter0 }}">
+                    {# Hidden input for Update (need id to associate) #}
+                    {% if summary.id.value %}
+                    <td class="original" hidden>
+                        <input id="id_compoundsummary_set-{{ forloop.counter0 }}-id" name="compoundsummary_set-{{ forloop.counter0 }}-id" type="hidden" value="{{ summary.id.value }}">
+                    </td>
+                    {% endif %}
+                    <td>{{ summary.summary_type }}</td>
+                    <td>{{ summary.summary }}</td>
+                    <td>{{ summary.DELETE }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+</form>
+
+{% endblock %}

--- a/mps/templates/drugtrials/adverse_events_list.html
+++ b/mps/templates/drugtrials/adverse_events_list.html
@@ -9,6 +9,7 @@
         <table hidden id="adverse_events" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View</th>
                     <th>Compound</th>
                     <th>Event</th>
                     <th>Frequency</th>
@@ -19,6 +20,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View</th>
                     <th>Compound</th>
                     <th>Event</th>
                     <th>Frequency</th>
@@ -30,6 +32,7 @@
             <tbody>
             {% for adverse_event in object_list %}
                 <tr class="adverse_event" id={{ adverse_event.id }}>
+                    <td><a class="btn btn-primary" href="{{ adverse_event.compound.id }}">View</a></td>
                     <td><a href="{{ adverse_event.compound.id }}">{{ adverse_event.compound.compound }}</a></td>
                     <td><a href="https://en.wikipedia.org/wiki/{{ adverse_event.event|lower }}">{{ adverse_event.event }}</a></td>
                     <td>{{ adverse_event.frequency }}</td>
@@ -51,9 +54,15 @@
                 dom: 'T<"clear">lfrtip',
                 "iDisplayLength": 50,
                 // Initially sort on compound and frequency
-                "order": [[ 0, "asc" ], [ 2, "desc"]],
+                "order": [[ 1, "asc" ], [ 3, "desc"]],
                 // Try to improve speed
-                "deferRender": true
+                "deferRender": true,
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/drugtrials/drugtrial_list.html
+++ b/mps/templates/drugtrials/drugtrial_list.html
@@ -45,11 +45,7 @@
             {% for finding in object_list %}
                 <tr class="finding" id={{ finding.id }}>
                     <td><a class="btn btn-primary" href="{{ finding.drug_trial.id }}">View</a></td>
-                    <td>
-                        <a href="/drugtrials/{{ finding.drug_trial.id }}">
-                            {{ finding.drug_trial.id }}
-                        </a>
-                    </td>
+                    <td>{{ finding.drug_trial.id }}</td>
                     <td>
                         <a href="/compounds/{{ finding.drug_trial.compound.id }}">
                             {{ finding.drug_trial.compound }}

--- a/mps/templates/drugtrials/drugtrial_list.html
+++ b/mps/templates/drugtrials/drugtrial_list.html
@@ -9,6 +9,7 @@
         <table hidden id="drugtrials" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View</th>
                     <th>Drug Trial ID</th>
                     <th>Compound</th>
                     <th>Species</th>
@@ -25,6 +26,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View</th>
                     <th>Drug Trial ID</th>
                     <th>Compound</th>
                     <th>Species</th>
@@ -42,6 +44,7 @@
             <tbody>
             {% for finding in object_list %}
                 <tr class="finding" id={{ finding.id }}>
+                    <td><a class="btn btn-primary" href="{{ finding.drug_trial.id }}">View</a></td>
                     <td>
                         <a href="/drugtrials/{{ finding.drug_trial.id }}">
                             {{ finding.drug_trial.id }}
@@ -91,13 +94,18 @@
                 "iDisplayLength": 50,
                 "deferRender": true,
                 // Initially sort on compound, not arbitrary ID
-                "order": [[ 1, "asc" ], [ 0, "asc"]],
-
+                "order": [[ 2, "asc" ], [ 1, "asc"]],
                 // Apply custom sorting priorities to frequency column
                 "columnDefs": [{
                     "type": "frequency-range",
-                    "targets": 7
-                }]
+                    "targets": 8
+                }],
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/index.html
+++ b/mps/templates/index.html
@@ -119,6 +119,7 @@
                             <li><a href="/drugtrials/">View Drug Trials</a></li>
                             <li><a href="/compounds/">View Chemical Data</a></li>
                             <li><a href="/adverse_events/">View Adverse Events</a></li>
+                            <li><a href="/compounds/report/#filter">Compound Report</a></li>
                           </ul>
                         </div>
                     </div>

--- a/mps/templates/index.html
+++ b/mps/templates/index.html
@@ -145,12 +145,12 @@
             </div>
                 <div class="col-sm-6 col-md-3">
                     <div title="View a table of bioactivities based on your selection" class="well">
-                        <a href="/bioactivities/table/">
+                        <a href="/bioactivities/table/#filter">
                             <img src="/static/img/button_addcompound.png"
                                  style="height: 70px;">
                         </a>
                         <div class="caption">
-                            <a href="/bioactivities/table/"
+                            <a href="/bioactivities/table/#filter"
                                class="btn btn-primary btn-large">
                                 View Bioactivities
                             </a>
@@ -225,12 +225,12 @@
         <div class="row">
             <div class="col-sm-6 col-md-4">
                 <div title="Generate a heatmap for selected bioactivity data" class="well">
-                    <a href="/bioactivities/heatmap">
+                    <a href="/bioactivities/heatmap/#filter">
                         <img src="/static/img/button_heatmap.png"
                              style="height: 70px;">
                     </a>
                     <div class="caption">
-                        <a href="/bioactivities/heatmap"
+                        <a href="/bioactivities/heatmap/#filter"
                            class="btn btn-primary btn-large">
                         Create Heatmap
                         </a>
@@ -239,12 +239,12 @@
             </div>
             <div class="col-sm-6 col-md-4">
                 <div title="Generate a dendrogram for selected compound/bioactivity data" class="well">
-                    <a href="/bioactivities/cluster">
+                    <a href="/bioactivities/cluster/#filter">
                         <img src="/static/img/button_cluster.png"
                              style="height: 70px;">
                     </a>
                     <div class="caption">
-                        <a href="/bioactivities/cluster"
+                        <a href="/bioactivities/cluster/#filter"
                            class="btn btn-primary btn-large">
                             Cluster Compounds
                         </a>

--- a/mps/templates/microdevices/microdevice_list.html
+++ b/mps/templates/microdevices/microdevice_list.html
@@ -10,6 +10,7 @@
         <table hidden id="models" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View</th>
                     <th>Organ</th>
                     <th>Model Name</th>
                     <th>Device</th>
@@ -20,6 +21,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View</th>
                     <th>Organ</th>
                     <th>Model Name</th>
                     <th>Device</th>
@@ -31,6 +33,7 @@
             <tbody>
             {% for model in models %}
                 <tr class="model" id={{ model.id }} name={{ model.device_name }}>
+                    <td><a class="btn btn-primary" href="{{ model.id }}">View</a></td>
                     <td><a href="model/{{ model.id }}">{{ model.organ|default_if_none:"" }}</a></td>
                     <td><a href="model/{{ model.id }}">{{ model.model_name }}</a></td>
                     <td><a href="device/{{ model.device.id }}">{{ model.device|default_if_none:"" }}</a></td>
@@ -46,6 +49,7 @@
         <table hidden id="microdevices" class="display" cellspacing="0" width="100%">
             <thead>
                 <tr>
+                    <th>View</th>
                     <th>Device Name</th>
                     <th>Manufacturer</th>
                     <th>Center</th>
@@ -56,6 +60,7 @@
 
             <tfoot>
                 <tr>
+                    <th>View</th>
                     <th>Device Name</th>
                     <th>Manufacturer</th>
                     <th>Center</th>
@@ -67,6 +72,7 @@
             <tbody>
             {% for microdevice in devices %}
                 <tr class="microdevice" id={{ microdevice.id }} name={{ microdevice.device_name }}>
+                    <td><a class="btn btn-primary" href="{{ microdevice.id }}">View</a></td>
                     <td><a href="device/{{ microdevice.id }}">{{ microdevice.device_name }}</a></td>
                     <td>{{ microdevice.manufacturer|default_if_none:"" }}</td>
                     <td>{{ microdevice.center|default_if_none:"" }}</td>
@@ -83,11 +89,23 @@
         $(document).ready(function() {
             $('#microdevices').DataTable({
                 "iDisplayLength": 200,
-                "sDom": '<T<"clear">t>'
+                "sDom": '<T<"clear">t>',
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
             $('#models').DataTable({
                 "iDisplayLength": 200,
-                "sDom": '<T<"clear">t>'
+                "sDom": '<T<"clear">t>',
+                "aoColumnDefs": [
+                    {
+                        "bSortable": false,
+                        "aTargets": [0]
+                    }
+                ]
             });
         });
     </script>

--- a/mps/templates/microdevices/microdevice_list.html
+++ b/mps/templates/microdevices/microdevice_list.html
@@ -90,6 +90,7 @@
             $('#microdevices').DataTable({
                 "iDisplayLength": 200,
                 "sDom": '<T<"clear">t>',
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,
@@ -100,6 +101,7 @@
             $('#models').DataTable({
                 "iDisplayLength": 200,
                 "sDom": '<T<"clear">t>',
+                "order": [[ 1, "asc" ]],
                 "aoColumnDefs": [
                     {
                         "bSortable": false,

--- a/mps/templates/microdevices/microdevice_list.html
+++ b/mps/templates/microdevices/microdevice_list.html
@@ -33,9 +33,9 @@
             <tbody>
             {% for model in models %}
                 <tr class="model" id={{ model.id }} name={{ model.device_name }}>
-                    <td><a class="btn btn-primary" href="{{ model.id }}">View</a></td>
-                    <td><a href="model/{{ model.id }}">{{ model.organ|default_if_none:"" }}</a></td>
-                    <td><a href="model/{{ model.id }}">{{ model.model_name }}</a></td>
+                    <td><a class="btn btn-primary" href="model/{{ model.id }}">View</a></td>
+                    <td>{{ model.organ|default_if_none:"" }}</td>
+                    <td>{{ model.model_name }}</td>
                     <td><a href="device/{{ model.device.id }}">{{ model.device|default_if_none:"" }}</a></td>
                     <td>{{ model.center|default_if_none:"" }}</td>
                     <td>{{ model.description }}</td>
@@ -72,8 +72,8 @@
             <tbody>
             {% for microdevice in devices %}
                 <tr class="microdevice" id={{ microdevice.id }} name={{ microdevice.device_name }}>
-                    <td><a class="btn btn-primary" href="{{ microdevice.id }}">View</a></td>
-                    <td><a href="device/{{ microdevice.id }}">{{ microdevice.device_name }}</a></td>
+                    <td><a class="btn btn-primary" href="device/{{ microdevice.id }}">View</a></td>
+                    <td>{{ microdevice.device_name }}</td>
                     <td>{{ microdevice.manufacturer|default_if_none:"" }}</td>
                     <td>{{ microdevice.center|default_if_none:"" }}</td>
                     <td>{{ microdevice.organ|default_if_none:"" }}</td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,5 +65,4 @@ django-alphafilter
 django-contrib-comments
 #Using whoosh for now, may switch to a more sophisticated search engine later
 whoosh
-#Sometimes pip installing django-haystack tries to force install django 1.8?
 django-haystack

--- a/scripts/update_pubchem.py
+++ b/scripts/update_pubchem.py
@@ -138,7 +138,7 @@ def get_pubchem_target(target):
         # If the target is in the database
         try:
             final_target = Target.objects.get(GI=target)
-            print "Found target!"
+            #print "Found target!"
         # If the target is not in the database, create it
         except:
 
@@ -180,7 +180,7 @@ def get_pubchem_target(target):
 
                 target_model = Target.objects.create(locked=True, **entry)
                 final_target = target_model
-                print "Created target!"
+                #print "Created target!"
 
             except:
 
@@ -309,7 +309,7 @@ def get_bioactivities(cid):
                             if not target_model.target_type:
                                 target_model.target_type = target_type
                                 target_model.save()
-                        print "Found assay!"
+                        #print "Found assay!"
 
                     except:
                         source = assay.get('SourceName')
@@ -335,7 +335,7 @@ def get_bioactivities(cid):
                             entry.update({'target': get_pubchem_target(target)})
 
                         assay_model = Assay.objects.create(locked=True, **entry)
-                        print "Created assay!"
+                        #print "Created assay!"
 
                     activities_to_change = assays.get(aid)
 
@@ -460,7 +460,7 @@ def run():
             if not chembl_assay:
                 try:
                     assay_query = Assay.objects.filter(pk=assay.id)
-                    print 'Updating', data.get('chemblid')
+                    #print 'Updating', data.get('chemblid')
                     assay_query.update(**data)
                     updates += 1
                 except Exception as e:
@@ -470,7 +470,7 @@ def run():
             # Update the chembl assay with pubchem data then delete the old assay
             else:
                 try:
-                    print 'Replacing', chembl_assay[0].chemblid
+                    #print 'Replacing', chembl_assay[0].chemblid
                     chembl_assay.update(**data)
                     chembl_assay.update(**{'pubchem_id':assay.pubchem_id, 'source':assay.source, 'source_id':assay.source_id})
                     # Switch bioactivities to the correct assay
@@ -515,5 +515,13 @@ def run():
                         PubChemBioactivity.objects.filter(pk=pk).update(normalized_value=bio_value[index])
                     except:
                         print 'Update of bioactivity {} failed'.format(pk)
+
+    print 'Adding SINGLE PROTEIN to NCBI target entries'
+
+    no_type = Target.objects.filter(target_type__isnull=True) | Target.objects.filter(target_type=u'')
+
+    for target in no_type.exclude(GI=u''):
+        target.target_type = 'SINGLE PROTEIN'
+        target.save()
 
     print 'Finished'

--- a/scripts/update_pubchem.py
+++ b/scripts/update_pubchem.py
@@ -175,6 +175,7 @@ def get_pubchem_target(target):
                     'name': name,
                     'organism': organism,
                     'GI': target,
+                    'target_type': 'SINGLE PROTEIN'
                 }
 
                 target_model = Target.objects.create(locked=True, **entry)
@@ -184,9 +185,10 @@ def get_pubchem_target(target):
             except:
 
                 entry = {
-                    'name': '',
-                    'organism': '',
+                    'name': name,
+                    'organism': organism,
                     'GI': target,
+                    'target_type': 'SINGLE PROTEIN'
                 }
 
                 target_model = Target.objects.create(locked=True, **entry)


### PR DESCRIPTION
- Use curated PubChem in lieu of ChEMBL as primary source for bioactivities
- Deprecate PubChemAssay and PubChemTarget, merge into Assay and Target respectively
- PLEASE BE SURE TO RUN CONVERSION SCRIPT AND REFRESH PUBCHEMBIOACTIVITIES
- Add inlines for additional compound properties and summaries
- Add buttons to disambiguate view, edit, and the following of links
- Add a way to create compound reports
- Use hash tracking to make the back button functional for bioactivity views
- Upgrade D3 and C3
- Increase the size of the study configuration graphs
- Allow config labels to be 2 characters and use - as a delimiter