### PR TITLE
Bug Fixes: Trim Data for Validation and more

### DIFF
--- a/assays/admin.py
+++ b/assays/admin.py
@@ -345,6 +345,17 @@ class AssayModelAdmin(LockableAdmin):
     )
 
     def save_model(self, request, obj, form, change):
+        template_change = False
+
+        # Check whether template needs to change
+        # Change if assay name has changed or it is new
+        if obj.pk is not None:
+            original = AssayModel.objects.get(pk=obj.pk)
+            if original.assay_name != obj.assay_name:
+                template_change = True
+        else:
+            template_change = True
+
         if change:
             obj.modified_by = request.user
         else:
@@ -352,7 +363,7 @@ class AssayModelAdmin(LockableAdmin):
 
         obj.save()
 
-        if change:
+        if template_change:
             modify_templates()
 
 
@@ -1647,7 +1658,8 @@ class PhysicalUnitsAdmin(LockableAdmin):
 
         obj.save()
 
-        if change and 'readout' in obj.availability:
+        # If this is a readout unit, modify the templates
+        if 'readout' in obj.availability:
             modify_templates()
 
 

--- a/assays/ajax.py
+++ b/assays/ajax.py
@@ -240,6 +240,7 @@ def fetch_center_id(request):
                         content_type="application/json")
 
 
+# TODO Needs refactor
 def fetch_chip_readout(request):
     """Returns the Raw Chip Data stored for a Chip Readout"""
 

--- a/assays/forms.py
+++ b/assays/forms.py
@@ -631,7 +631,8 @@ def validate_plate_readout_file(
     # If not block, then it is TABULAR data
     else:
         # Purge empty lines, they are useless for tabular uploads
-        datalist = [row for row in datalist if any(row)]
+        # All lines that do not have anything in their first 8 cells are purged
+        datalist = [row for row in datalist if any(row[:8])]
         # The first line SHOULD be the header
         header = datalist[0]
 
@@ -719,7 +720,7 @@ def validate_plate_readout_file(
 
                 # Check time unit
                 # TODO make a better fuzzy match, right now just checks to see if the first letters correspond
-                if time_unit[0] != readout_time_unit[0]:
+                if not time_unit or (time_unit[0] != readout_time_unit[0]):
                     raise forms.ValidationError(
                         sheet + 'Plate-%s: The time unit "%s" does not correspond with the selected readout time unit '
                                 'of "%s"'
@@ -958,7 +959,7 @@ def validate_chip_readout_file(
 
         # Fail if time unit does not match
         # TODO make a better fuzzy match, right now just checks to see if the first letters correspond
-        if time_unit[0] != readout_time_unit[0]:
+        if not time_unit or (time_unit[0] != readout_time_unit[0]):
             raise forms.ValidationError(
                 sheet + 'Chip-%s: The time unit "%s" does not correspond with the selected readout time unit of "%s"'
                 % (chip_id, time_unit, readout_time_unit)

--- a/assays/static/assays/customize_plate_readout.js
+++ b/assays/static/assays/customize_plate_readout.js
@@ -272,8 +272,8 @@ $(document).ready(function () {
 //                }
 
                 // Check if there is already an input, if so, delete it
-                if ($('#' + invalid_id)[0]) {
-                    $('#' + invalid_id).remove();
+                if ($('[id="'+ invalid_id + '"]')[0]) {
+                    $('[id="'+ invalid_id + '"]').remove();
                     $(this).removeClass('invalid-well');
 
                     invalid[current_selection][current_time] = _.without(invalid[current_selection][current_time], '#' + id);

--- a/assays/static/assays/customize_plate_readout.js
+++ b/assays/static/assays/customize_plate_readout.js
@@ -1058,7 +1058,7 @@ $(document).ready(function () {
         current_assay_feature = current_assay_feature.replace('.', '\\.');
 
         // Show this feature's values
-        $('p[data-assay-feature-time=' + current_assay_feature + ']').show();
+        $('p[data-assay-feature-time="' + current_assay_feature + '"]').show();
         refresh_invalid();
     });
 

--- a/assays/views.py
+++ b/assays/views.py
@@ -2116,14 +2116,18 @@ class ReadoutBulkUpload(ObjectGroupRequiredMixin, UpdateView):
                     # Skip header
                     for row_index in range(1, sheet.nrows):
                         row = [stringify_excel_value(value) for value in sheet.row_values(row_index)]
-                        chip_id = row[0]
 
-                        if chip_id not in csv_data:
-                            csv_data.update({
-                                chip_id: [header]
-                            })
+                        # Make sure the data is valid before adding it
+                        # The first 7 cells need to be filled for a row to be valid
+                        if row and all(row[:7]):
+                            chip_id = row[0]
 
-                        csv_data.get(chip_id).append(row)
+                            if chip_id not in csv_data:
+                                csv_data.update({
+                                    chip_id: [header]
+                                })
+
+                            csv_data.get(chip_id).append(row)
 
                     for chip_id in csv_data:
                         datalist = csv_data.get(chip_id)
@@ -2179,14 +2183,18 @@ class ReadoutBulkUpload(ObjectGroupRequiredMixin, UpdateView):
                     # Skip header
                     for row_index in range(1, sheet.nrows):
                         row = [stringify_excel_value(value) for value in sheet.row_values(row_index)]
-                        plate_id = row[0]
 
-                        if plate_id not in csv_data:
-                            csv_data.update({
-                                plate_id: [header]
-                            })
+                        # Make sure the data is valid before adding it
+                        # The first 6 cells must be filled (time and time unit are not required)
+                        if row and all(row[:6]):
+                            plate_id = row[0]
 
-                        csv_data.get(plate_id).append(row)
+                            if plate_id not in csv_data:
+                                csv_data.update({
+                                    plate_id: [header]
+                                })
+
+                            csv_data.get(plate_id).append(row)
 
                     for plate_id in csv_data:
                         datalist = csv_data.get(plate_id)

--- a/cellsamples/ajax.py
+++ b/cellsamples/ajax.py
@@ -15,7 +15,11 @@ def get_cell_subtypes(request):
 
     cell_type = request.POST.get('cell_type')
 
-    findings = CellSubtype.objects.filter(cell_type_id=cell_type) | CellSubtype.objects.filter(cell_type__isnull=True)
+    findings = CellSubtype.objects.filter(cell_type__isnull=True)
+
+    if cell_type:
+        findings = findings | CellSubtype.objects.filter(cell_type_id=cell_type)
+
     findings = findings.order_by('cell_type', 'cell_subtype')
 
     for finding in findings:

--- a/cellsamples/static/cellsamples/cellsample_add.js
+++ b/cellsamples/static/cellsamples/cellsample_add.js
@@ -34,7 +34,7 @@ $(function() {
                 var options = json.context;
                 var current_value = subtype.val();
                 subtype.html(options);
-                if ($('#id_cell_subtype option[value='+current_value+']')[0]) {
+                if (current_value && $('#id_cell_subtype option[value='+current_value+']')[0]) {
                     subtype.val(current_value);
                 }
                 else {


### PR DESCRIPTION
- This is to resolve a bug where validation cells are registered as data and cause various issues in chip and tabular plate readout uploads.
- Solving the issue is as simple as restricting validation to look at only pertinent columns.
- This request also resolves an issue where not providing a time unit caused a less-than-graceful crash in readout uploads.
- Bug fix for unexpected behaviour in cell samples
- Bug fix: spaces in feature name no longer crash plate readouts (really, spaces and a number of other characters, like quotation marks, should just be forbidden)
- Revise when templates are changed