### PR TITLE
change to m2m from xref

### DIFF
--- a/mps/templates/help.html
+++ b/mps/templates/help.html
@@ -5376,7 +5376,7 @@ Results: add a summary of the study results. </td>
             <th>Term</th>
             <th>Definition</th>
             <th>Ref</th>
-            <th>Help</th>
+{#            <th>Help</th>#}
           </tr>
         </thead>
 
@@ -5386,7 +5386,7 @@ Results: add a summary of the study results. </td>
               <td>{{ term.term }}</td>
               <td>{{ term.definition }}</td>
               <td>{{ term.show_url }}</td>
-              <td>{{ term.show_anchor }}</td>
+{#              <td>{{ term.show_anchor }}</td>#}
             </tr>
           {% endfor %}
         </tbody>

--- a/mps/views.py
+++ b/mps/views.py
@@ -22,7 +22,7 @@ import os
 
 from mps.settings import MEDIA_ROOT
 
-from resources.models import Definition, ComingSoonEntry, WhatIsNewEntry, FeatureSourceXref
+from resources.models import Definition, ComingSoonEntry, WhatIsNewEntry
 from django.views.generic.base import TemplateView
 
 from microdevices.models import MicrophysiologyCenter
@@ -134,95 +134,11 @@ def custom_search(request):
 
 
 def mps_help(request):
-    glossary = Definition.objects.exclude(definition='')
-
-    xref = FeatureSourceXref.objects.all(
-    ).order_by(
-        'database_feature', 'data_source'
-    ).prefetch_related(
-        'data_source',
-    )
-
-    feature_source = {}
-    list_of_sources = []
-    f = ''
-    i = 0
-
-    # make a list of the data sources associated with each feature using the xref table
-    # store in a dictionary of feature and list of data sources
-    for each in xref:
-        sn = str(each.data_source.help_order)
-
-        # print('each.database_feature: ',each.database_feature)
-        # print('sn: ', sn)
-
-        # HANDY - get each field name in a queryset
-        # for field in each._meta.get_fields():
-        #     print(field)
-
-        if i > 0 and i+1 < len(xref) and f == each.database_feature:
-            # print('not first, not last, same feature')
-            # write this data source to the list of data sources for this feature
-            list_of_sources.append(sn)
-        elif i > 0 and i+1 < len(xref) and f != each.database_feature:
-            # print('not first, not last, feature changed')
-            # write the previous feature and the list so far to the dictionary
-            feature_source[f] = list_of_sources
-            # reset the list to the current source
-            list_of_sources = [sn]
-        elif i > 0 and i + 1 == len(xref) and f == each.database_feature:
-            # print('not first, IS last, same feature')
-            # write this data source to the list of data sources for this feature
-            list_of_sources.append(sn)
-            # write the previous/this feature and the list so far to the dictionary
-            feature_source[f] = list_of_sources
-            list_of_sources = []
-        elif i > 0 and i + 1 == len(xref) and f != each.database_feature:
-            # print('not first, IS last, feature changed (last one is a different feature)')
-            # write the previous feature and the list so far to the dictionary
-            feature_source[f] = list_of_sources
-            # write this data source to the list of data sources
-            list_of_sources = [sn]
-            # write the list (of one) to the dictionary of features
-            feature_source[each.database_feature] = list_of_sources
-        elif i == 0 and i+1 < len(xref):
-            # print('the first, not last')
-            # write this data source to the list of data sources for this feature
-            list_of_sources.append(sn)
-        else:
-            # print('the first and only')
-            # write this data source to the list of data sources
-            list_of_sources = [sn]
-            # write the list (of one) to the dictionary of features
-            feature_source[each.database_feature] = list_of_sources
-            list_of_sources = []
-
-        # print('list_of_sources: ',list_of_sources)
-
-        f = each.database_feature
-        i = i + 1
-
-    # print('feature_source: ', feature_source)
+    glossary = Definition.objects.exclude(definition=''
+    ).prefetch_related('data_sources', )
 
     # get a subset of the features for the feature table
     feature = glossary.filter(help_category='feature').order_by('help_order')
-
-    # add a field to the feature queryset that has the list (stringified) of the data source(s) for each feature
-    # HANDY - add field to queryset add a field to a queryset
-    for each in feature:
-        # print('---each.reference ', each.reference)
-        # print('each.help_reference ', each.help_reference)
-
-        this_feature = each
-        this_list = feature_source.get(this_feature)
-        try:
-            this_list_string = ', '.join(map(str, this_list))
-        except:
-            this_list_string = ''
-        each.source_list = this_list_string
-
-    # for each in feature:
-    #     print('each.source_list: ', each.source_list)
 
     # get other subsets for other tables on the help page
     source = glossary.filter(help_category='source').order_by('help_order')
@@ -230,6 +146,17 @@ def mps_help(request):
     component_model = glossary.filter(help_category='component-model').order_by('help_order')
     component_compound = glossary.filter(help_category='component-compound').order_by('help_order')
     component_cell = glossary.filter(help_category='component-cell').order_by('help_order')
+
+    all_glossary = {}
+    for each in glossary:
+        term = each.term
+        stripped_term = ''.join(e for e in term if e.isalnum())
+        stripped_term = stripped_term.lower()
+        # print("stripped_term: ", stripped_term)
+        all_glossary[stripped_term+'_def'] = each.definition
+        all_glossary[stripped_term+'_ref'] = each.show_url
+
+    # print("all_glossary ", all_glossary)
 
     # limit the glossary to only those selected for display
     glossary = glossary.filter(glossary_display=True)
@@ -243,10 +170,11 @@ def mps_help(request):
         'component_model': component_model,
         'component_compound': component_compound,
         'component_cell': component_cell,
+        'study_component_def': all_glossary.get('studycomponent_def', ''),
+        'study_component_ref': all_glossary.get('studycomponent_ref', ''),
     }
 
     return render(request, 'help.html', data)
-
 
 #added sck
 # TODO NOT DRY

--- a/resources/admin.py
+++ b/resources/admin.py
@@ -11,7 +11,6 @@ from resources.models import (
     Definition,
     ComingSoonEntry,
     WhatIsNewEntry,
-    FeatureSourceXref,
 )
 from resources.forms import (
     ResourceForm,
@@ -145,6 +144,7 @@ class DefinitionAdmin(LockableAdmin):
         'definition',
         'is_url',
         'help_category',
+        'is_data_sources',
         'help_order',
         'is_anchor',
         'modified_on',
@@ -162,6 +162,7 @@ class DefinitionAdmin(LockableAdmin):
                     'definition',
                     'reference',
                     'help_category',
+                    'data_sources',
                     'order_numbers_already_assigned',
                     'help_order',
                     'help_reference',
@@ -203,11 +204,3 @@ class WhatIsNewEntryAdmin(LockableAdmin):
     list_editable = ['contents', 'short_contents']
 
 admin.site.register(WhatIsNewEntry, WhatIsNewEntryAdmin)
-
-
-class FeatureSourceXrefAdmin(LockableAdmin):
-    model = FeatureSourceXref
-    list_display = ['database_feature', 'data_source']
-    search_fields = ['database_feature', 'data_source', ]
-
-admin.site.register(FeatureSourceXref, FeatureSourceXrefAdmin)

--- a/resources/forms.py
+++ b/resources/forms.py
@@ -79,6 +79,3 @@ class DefinitionForm(forms.ModelForm):
             attrs={'rows': number_cats+2, 'cols': 75, 'readonly': 'readonly'}
         )
     )
-#     plate-label
-# map-label
-# , 'class': 'plate-map-special-well'

--- a/resources/models.py
+++ b/resources/models.py
@@ -62,6 +62,17 @@ help_category_choices = [
     ('component-model', 'component-model')
 ]
 
+
+help_category_choices = [
+    ('feature', 'feature'),
+    ('source', 'source'),
+    ('component-cell', 'component-cell'),
+    ('component-assay', 'component-assay'),
+    ('component-compound', 'component-compound'),
+    ('component-model', 'component-model')
+]
+
+
 class Definition(LockableModel):
     """A Definition is a definition for the glossary found in Help"""
     class Meta(object):
@@ -87,6 +98,12 @@ class Definition(LockableModel):
        help_text=(
            'Check to display in tables and other locations in the help page (does not apply to the glossary).'
        ), )
+    data_sources = models.ManyToManyField(
+        to='self',
+        blank=True,
+        limit_choices_to={'help_category': 'source'},
+        related_name='data_sources',
+    )
 
     # def __str__(self):
     #     return self.term
@@ -132,6 +149,14 @@ class Definition(LockableModel):
             return False
     is_anchor.boolean = True
 
+    def is_data_sources(self):
+        if self.data_sources is None:
+            return True
+        else:
+            return False
+    is_data_sources.boolean = True
+
+
 class ComingSoonEntry(LockableModel):
     """An entry for the About Page's "Coming Soon" Section"""
     class Meta(object):
@@ -149,26 +174,3 @@ class WhatIsNewEntry(LockableModel):
 
     contents = models.TextField(default='')
     short_contents = models.TextField(default='')
-
-
-class FeatureSourceXref(LockableModel):
-    """Database Features - for table in Help"""
-    class Meta(object):
-        verbose_name = 'Help - Database Features & Sources'
-        verbose_name_plural = 'Help - Database Features & Sources'
-        unique_together = [('database_feature', 'data_source')]
-
-    database_feature = models.ForeignKey(
-        Definition,
-        default=1,
-        related_name='database_feature',
-        on_delete=models.CASCADE,
-        limit_choices_to={'help_category': 'feature'},
-    )
-    data_source = models.ForeignKey(
-        Definition,
-        default=1,
-        related_name='data_source',
-        on_delete=models.CASCADE,
-        limit_choices_to={'help_category': 'source'},
-    )


### PR DESCRIPTION
Migration needed. Removes the Xref table and, instead, adds a m2m field to the Definitions table. The help page should stay the same (except the link to the help tag in the glossary was removed).