### PR TITLE
change default order in the admin to make editing glossary easier

### DIFF
--- a/resources/admin.py
+++ b/resources/admin.py
@@ -136,9 +136,11 @@ class DefinitionAdmin(LockableAdmin):
     """Admin for Definitions"""
     form = DefinitionForm
     save_on_top = True
-    ordering = (
+    ordering = [
+        '-help_category',
+        'help_order',
         'term',
-    )
+    ]
     list_per_page = 300
     list_display = (
         'term',


### PR DESCRIPTION
Change default order of admin to make editing glossary easier for sck.